### PR TITLE
Fix #24 update usb package

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "terser": "^4.6.3",
     "typeface-roboto": "^0.0.54",
     "typeface-source-code-pro": "^0.0.71",
-    "usb": "^1.6.2"
+    "usb": "^1.6.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12931,10 +12931,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-usb@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/usb/-/usb-1.6.2.tgz#4ed7f0d8631c70192b33635f6a4e700d9e6bfe62"
-  integrity sha512-KcovLXRQuH63iEtnqXyDQGOi5dXHpLM5lZBIUsqSJQToua8nL2sVCieQTkzQBfLe5mCuvk40MgKciI61lgevWw==
+usb@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-1.6.3.tgz#c0bc14994e8f9cb16f9602ec0dbadaa57cb919f5"
+  integrity sha512-23KYMjaWydACd8wgGKMQ4MNwFspAT6Xeim4/9Onqe5Rz/nMb4TM/WHL+qPT0KNFxzNKzAs63n1xQWGEtgaQ2uw==
   dependencies:
     bindings "^1.4.0"
     nan "2.13.2"


### PR DESCRIPTION
Fix #24 
- Update the usb package to 1.6.3 .
    - Related 1: https://github.com/tessel/node-usb/pull/348
    - Related 2: https://github.com/tessel/node-usb/releases/tag/v1.6.3