### PR TITLE
Add oneshot layers 8 & 9 to db

### DIFF
--- a/src/api/keymap/db/oneshot.js
+++ b/src/api/keymap/db/oneshot.js
@@ -151,6 +151,20 @@ const OneShotLayerTable = {
         top: "OSL",
         primary: "7"
       }
+    },
+    {
+      code: 49169,
+      labels: {
+        top: "OSL",
+        primary: "8"
+      }
+    },
+    {
+      code: 49170,
+      labels: {
+        top: "OSL",
+        primary: "9"
+      }
     }
   ]
 };


### PR DESCRIPTION
closes #54 

Per [issue 54](https://github.com/Dygmalab/Bazecor/issues/54) layers 8
and 9 are missing from KEY CONFIG options.

This has been built and tested on Windows configuration and is expected
to be cross platform friendly.

Testing was to:
- build and run windows version
- confirm presence of layers
- assign oneshot layer 8 and 9 to an earlier layer
- confirm display of key and execution of the correct action

Signed-off-by: Abby Bangser <bangser.a@gmail.com>