### PR TITLE
111 enhance import export layers

### DIFF
--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -47,7 +47,6 @@ import SaveChangesButton from "../../components/SaveChangesButton";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import i18n from "../../i18n";
 import settings from "electron-settings";
-import ImportExportDialog from "./ImportExportDialog";
 import { CopyFromDialog } from "./CopyFromDialog";
 import { undeglowDefaultColors } from "./initialUndaglowColors";
 
@@ -915,8 +914,8 @@ class Editor extends React.Component {
 
   toImport() {
     let options = {
-      title: "Load Layers file",
-      buttonLabel: "Load Layers",
+      title: "Load Layer file",
+      buttonLabel: "Load Layer",
       filters: [
         { name: "Json", extensions: ["json"] },
         { name: "All Files", extensions: ["*"] }
@@ -932,7 +931,7 @@ class Editor extends React.Component {
           let layers;
           try {
             layers = JSON.parse(require("fs").readFileSync(resp.filePaths[0]));
-            console.log(layers.keymap.custom[0]);
+            console.log(layers.keymap[0]);
             this.props.enqueueSnackbar("Imported succesfully", {
               variant: "success",
               autoHideDuration: 2000
@@ -956,19 +955,32 @@ class Editor extends React.Component {
   }
 
   toExport() {
+    const { keymap, currentLayer } = this.state;
+    let layerData, isReadOnly;
+    if (keymap.onlyCustom) {
+      isReadOnly = currentLayer < 0;
+      layerData = isReadOnly
+        ? keymap.default[currentLayer + keymap.default.length]
+        : keymap.custom[currentLayer];
+    } else {
+      isReadOnly = currentLayer < keymap.default.length;
+      layerData = isReadOnly
+        ? keymap.default[currentLayer]
+        : keymap.custom[currentLayer - keymap.default.length];
+    }
     let data = JSON.stringify(
       {
-        keymap: this.state.keymap,
-        colormap: this.state.colormap,
+        keymap: layerData,
+        colormap: this.state.colorMap[currentLayer],
         palette: this.state.palette
       },
       null,
       2
     );
     let options = {
-      title: "Save Layers file",
-      defaultPath: "Layers",
-      buttonLabel: "Save Layers",
+      title: "Save Layer file",
+      defaultPath: "Layer",
+      buttonLabel: "Save Layer",
       filters: [
         { name: "Json", extensions: ["json"] },
         { name: "All Files", extensions: ["*"] }
@@ -1200,16 +1212,6 @@ class Editor extends React.Component {
           onCancel={this.cancelCopyFrom}
           layers={copyFromLayerOptions}
           currentLayer={currentLayer}
-        />
-        <ImportExportDialog
-          open={this.state.importExportDialogOpen}
-          keymap={layerData}
-          palette={this.state.palette}
-          colormap={this.state.colorMap[this.state.currentLayer]}
-          isReadOnly={isReadOnly}
-          onConfirm={this.importLayer}
-          onCancel={this.cancelImport}
-          toCloseImportExportDialog={this.toCloseImportExportDialog}
         />
       </React.Fragment>
     );

--- a/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
+++ b/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
@@ -75,7 +75,8 @@ export const ImportExportDialog = withSnackbar(props => {
   }
 
   function copyToClipboard(data) {
-    clipboard.writeText(data);
+    //clipboard.writeText(data);
+    toExport(data);
     setIsChange(false);
     props.enqueueSnackbar(i18n.editor.copySuccess, {
       variant: "success",
@@ -84,7 +85,8 @@ export const ImportExportDialog = withSnackbar(props => {
   }
 
   function pasteFromClipboard() {
-    setData(clipboard.readText());
+    //setData(clipboard.readText());
+    toImport();
     setIsChange(true);
     props.enqueueSnackbar(i18n.editor.pasteSuccess, {
       variant: "success",
@@ -102,6 +104,83 @@ export const ImportExportDialog = withSnackbar(props => {
       }
       setData(layoutData);
     });
+  }
+
+  function toImport() {
+    let options = {
+      title: "Load Layers file",
+      buttonLabel: "Load Layers",
+      filters: [
+        { name: "Json", extensions: ["json"] },
+        { name: "All Files", extensions: ["*"] }
+      ]
+    };
+    const remote = require("electron").remote;
+    const WIN = remote.getCurrentWindow();
+    remote.dialog
+      .showOpenDialog(WIN, options)
+      .then(resp => {
+        if (!resp.canceled) {
+          console.log(resp.filePaths);
+          let layers;
+          try {
+            layers = require("fs").readFileSync(resp.filePaths[0]);
+            console.log(JSON.parse(layers).keymap[0].label);
+            props.enqueueSnackbar("Imported succesfully", {
+              variant: "success",
+              autoHideDuration: 2000
+            });
+          } catch (e) {
+            console.error(e);
+            props.enqueueSnackbar("Not a valid Layer file", {
+              variant: "error",
+              autoHideDuration: 2000
+            });
+            return;
+          }
+          setData(layers);
+        } else {
+          console.log("user closed SaveDialog");
+        }
+      })
+      .catch(err => {
+        console.log(err);
+      });
+  }
+
+  function toExport(data) {
+    let options = {
+      title: "Save Layers file",
+      defaultPath: "Layers",
+      buttonLabel: "Save Layers",
+      filters: [
+        { name: "Json", extensions: ["json"] },
+        { name: "All Files", extensions: ["*"] }
+      ]
+    };
+    const remote = require("electron").remote;
+    const WIN = remote.getCurrentWindow();
+    remote.dialog
+      .showSaveDialog(WIN, options)
+      .then(resp => {
+        if (!resp.canceled) {
+          console.log(resp.filePath, data);
+          require("fs").writeFileSync(resp.filePath, data);
+          props.enqueueSnackbar("Export Successful", {
+            variant: "success",
+            autoHideDuration: 2000
+          });
+        } else {
+          console.log("user closed SaveDialog");
+        }
+      })
+      .catch(err => {
+        console.error(err);
+        props.enqueueSnackbar("Error at Exporting: " + err, {
+          variant: "error",
+          autoHideDuration: 2000
+        });
+      });
   }
 
   return (
@@ -127,10 +206,10 @@ export const ImportExportDialog = withSnackbar(props => {
           <LoadDefaultKeymap loadDefault={loadDefault} />
           <div>
             <Button color="primary" onClick={() => copyToClipboard(data)}>
-              {i18n.editor.copyToClipboard}
+              {"Export Layers"}
             </Button>
             <Button color="primary" onClick={pasteFromClipboard}>
-              {i18n.editor.pasteFromClipboard}
+              {"Import Layers"}
             </Button>
           </div>
         </div>

--- a/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
+++ b/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
@@ -75,7 +75,7 @@ export const ImportExportDialog = withSnackbar(props => {
   }
 
   function copyToClipboard(data) {
-    //clipboard.writeText(data);
+    clipboard.writeText(data);
     toExport(data);
     setIsChange(false);
     props.enqueueSnackbar(i18n.editor.copySuccess, {
@@ -85,7 +85,7 @@ export const ImportExportDialog = withSnackbar(props => {
   }
 
   function pasteFromClipboard() {
-    //setData(clipboard.readText());
+    setData(clipboard.readText());
     toImport();
     setIsChange(true);
     props.enqueueSnackbar(i18n.editor.pasteSuccess, {


### PR DESCRIPTION
Replaced old import export screen by two buttons with file access to avoid copying pasting from clipboard and leaving editor screen to do so.

this opens the possibility to backup all the layers if users are interested in it.