### PR TITLE
defaultPath in showSaveDialog doesn't include the default extension

### DIFF
--- a/src/renderer/components/MacroManager/MacroForm.js
+++ b/src/renderer/components/MacroManager/MacroForm.js
@@ -160,7 +160,7 @@ class MacroForm extends Component {
     });
     let options = {
       title: "Save Macro file",
-      defaultPath: this.state.name,
+      defaultPath: this.state.name + ".json",
       buttonLabel: "Save Macro",
       filters: [
         { name: "Json", extensions: ["json"] },
@@ -232,7 +232,7 @@ class MacroForm extends Component {
   toBackup() {
     let options = {
       title: "Backup Macros to file",
-      defaultPath: "allMacros",
+      defaultPath: "allMacros.json",
       buttonLabel: "Backup Macros",
       filters: [
         { name: "Json", extensions: ["json"] },

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -1003,7 +1003,7 @@ class Editor extends React.Component {
     );
     let options = {
       title: "Save Layer file",
-      defaultPath: "Layer" + currentLayer,
+      defaultPath: "Layer" + currentLayer + ".json",
       buttonLabel: "Save Layer",
       filters: [
         { name: "Json", extensions: ["json"] },
@@ -1048,7 +1048,7 @@ class Editor extends React.Component {
     );
     let options = {
       title: "Backup Layers file",
-      defaultPath: "Layers",
+      defaultPath: "Layers.json",
       buttonLabel: "Backup Layers",
       filters: [
         { name: "Json", extensions: ["json"] },

--- a/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
+++ b/src/renderer/screens/Editor/ImportExportDialog/ImportExportDialog.js
@@ -151,7 +151,7 @@ export const ImportExportDialog = withSnackbar(props => {
   function toExport(data) {
     let options = {
       title: "Save Layers file",
-      defaultPath: "Layers",
+      defaultPath: "Layers.json",
       buttonLabel: "Save Layers",
       filters: [
         { name: "Json", extensions: ["json"] },


### PR DESCRIPTION
This basically means the file will end up being exported without the extension as seen in #122. This PR fixes that by adding the default file extension to defaultPath.