### PR TITLE
Rename APP key to MENU

### DIFF
--- a/src/api/keymap/db/navigation.js
+++ b/src/api/keymap/db/navigation.js
@@ -73,7 +73,7 @@ const NavigationTable = {
     {
       code: 101,
       labels: {
-        primary: "APP"
+        primary: "MENU"
       }
     }
   ]


### PR DESCRIPTION
I was a bit confused as to what the App key did, and I found I'm not alone as per #33. It's true that its internal name is generally app key, but it is commonly referred to as the menu key (the wikipedia page for it is even called Menu key).

This PR fixed that by simply renaming it.