### PR TITLE
Rename Non-US backslash to ISO <>

### DIFF
--- a/src/api/keymap/db/punctuation.js
+++ b/src/api/keymap/db/punctuation.js
@@ -96,8 +96,8 @@ const PunctuationTable = {
     {
       code: 100,
       labels: {
-        primary: "ALT \\",
-        verbose: "Non-US \\"
+        primary: "ISO <>",
+        verbose: "ISO <>"
       }
     }
   ]


### PR DESCRIPTION
As per #51 the extra ISO key next to the left shift key is named rather confusingly. This fixes that by renaming it to ISO <>.
I don't know why it has the name it does now, or if this key is used for anything else, so if you'd rather keep it with the old name feel free to just close this.