### PR TITLE
Check if the focus command is supported when doing backup

### DIFF
--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -85,6 +85,9 @@ export default class FlashRaise {
    */
   async backupSettings() {
     let focus = new Focus();
+
+    let supportedCommands = await focus.command("help");
+
     const commands = [
       "hardware.keyscan",
       "led.mode",
@@ -103,6 +106,12 @@ export default class FlashRaise {
       const errorMessage =
         "Firmware update failed, because the settings could not be saved";
       for (let command of commands) {
+        // Ignore the command if it's not supported
+        if (supportedCommands.indexOf(command) == -1) {
+          this.backupFileData.log.push("Unsupported command " + command);
+          continue;
+        }
+
         let res = await focus.command(command);
         this.backupFileData.backup[command] =
           typeof res === "string" ? res.trim() : res;


### PR DESCRIPTION
As per #128, the firmware update can fail with "because the settings could not be saved" when you are on an older firmware. This is because the old firmwares didn't support certain command (specifically macros.map) and due to the way the focus api works it would only return an empty string causing errorFlag to be set to true.
This PR fixes that by using the very handy "help" command to check what commands are supported before doing the update, and skipping the ones it can't find.

I've tested the fix by downgrading to the firmware in the release/0.1.2 branch and tried to upgrade to latest. Without this fix it will throw the "settings could not be saved" error.

As an expansion of this PR, I feel like the Focus class should probably get the supported commands in the constructor, and do all the checking in there instead and possibly add a specific exception just for that (or a return value you can check for). This PR however is just a simple fix to get around the issue.