### PR TITLE
Fixed negative number and button without text

### DIFF
--- a/src/renderer/components/CustomDialog.js
+++ b/src/renderer/components/CustomDialog.js
@@ -92,7 +92,11 @@ class CustomDialog extends React.Component {
         <DialogContent>{this.props.children}</DialogContent>
         {this.props.countdown !== null && (
           <DialogActions>
-            <Countdown>{this.props.countdown}</Countdown>
+            {this.props.countdown < 0 ? (
+              <React.Fragment />
+            ) : (
+              <Countdown>{this.props.countdown}</Countdown>
+            )}
             <Countbutton
               onClick={this.props.countdown !== 0 ? this.props.upload : null}
               variant="contained"

--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -497,7 +497,7 @@ class FirmwareUpdate extends React.Component {
         <CustomDialog
           title={i18n.firmwareUpdate.raise.reset}
           open={this.state.confirmationOpen}
-          buttonText={buttonText[countdown]}
+          buttonText={countdown > -1 ? buttonText[countdown] : buttonText[""]}
           handleClose={this.cancelDialog}
           upload={this.upload}
           countdown={countdown}


### PR DESCRIPTION
Signed-off-by: AlexDygma <alex@dygma.com>

This commit solves the UI representation of the countdown timer for the flashing process when the keyboard is in bootloader mode.