### PR TITLE
Retrieve supported focus commands when opening the port

### DIFF
--- a/src/api/flash/index.js
+++ b/src/api/flash/index.js
@@ -86,8 +86,6 @@ export default class FlashRaise {
   async backupSettings() {
     let focus = new Focus();
 
-    let supportedCommands = await focus.command("help");
-
     const commands = [
       "hardware.keyscan",
       "led.mode",
@@ -107,7 +105,7 @@ export default class FlashRaise {
         "Firmware update failed, because the settings could not be saved";
       for (let command of commands) {
         // Ignore the command if it's not supported
-        if (supportedCommands.indexOf(command) == -1) {
+        if (!focus.isCommandSupported(command)) {
           this.backupFileData.log.push("Unsupported command " + command);
           continue;
         }
@@ -290,9 +288,8 @@ export default class FlashRaise {
       return;
     }
     try {
-      await focus.open(this.currentPort.path, this.currentPort.device.info);
       await focus
-        .probe()
+        .open(this.currentPort.path, this.currentPort.device.info)
         .then(async () => {
           const commands = Object.keys(this.backupFileData.backup);
           for (let command of commands) {


### PR DESCRIPTION
As I talked about in PR#132, this moves the retrieving of the supported focus commands to the Focus open code and make parts of the code use the new isCommandSupported method. This makes it easier to understand and also removes some duplicated code.
Because of this change I also had to move the stty clocal spawning to the port open method, to make sure it happens before running any commands on the port. This code is supposed to make the OSX connection more stable, so it should work the same way as before. I haven't tested it on OSX though as I only have access to Linux.

Do let me know if this makes sense, or if some parts need to be changed!