### PR TITLE
Workaround issue causing serial port data to be cut off

### DIFF
--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -182,7 +182,13 @@ class Focus {
     if (args && args.length > 0) {
       request = request + " " + args.join(" ");
     }
+
     request += "\n";
+
+    // Workaround: Even data lengths can sometimes cause the data to be cut off
+    if (request.length % 2 == 0) {
+      request += " ";
+    }
 
     if (process.platform == "darwin") {
       let parts = request.split(" ");


### PR DESCRIPTION
See #139 for more info. This is a simple workaround to fix an issue where the serial data is cut off when the data length is even. I haven't managed to figure out what the root cause of this is yet, but this PR will at least make it not fail.
It probably needs more testing, but shouldn't cause any issues as the appended space should simply be ignored in the firmware.