### PR TITLE
reverted serial timeout fix due to error in data reception

### DIFF
--- a/src/api/focus/index.js
+++ b/src/api/focus/index.js
@@ -200,13 +200,6 @@ class Focus {
     }
     request += "\n";
 
-    // Workaround only applies to non darwin O.S.
-    if (process.platform !== "darwin") {
-      // Workaround: Even data lengths can sometimes cause the data to be cut off
-      if (request.length % 2 == 0) {
-        request += " ";
-      }
-    }
     return new Promise(resolve => {
       this.callbacks.push(resolve);
       this._port.write(request);


### PR DESCRIPTION
This PR reverts the changes made in #139 to prevent timeouts when a even quantity of characters was being sent to the Raise keyboard. This affected the reception of data when it was being uploaded through Focus API. 

This is now fixed in the Firmware as stated in the issue.