### PR TITLE
fix: fixed sandbox check on non-hardened/upsteam linux kernel

### DIFF
--- a/build/launcher.sh
+++ b/build/launcher.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 set -e
 
-UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
+UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null || echo "0")
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-exec "$SCRIPT_DIR/bazecor-bin" "$([[ $UNPRIVILEGED_USERNS_ENABLED == 0 ]] && echo '--no-sandbox')" "$@"
+exec "$SCRIPT_DIR/bazecor-bin" "$([[ "$UNPRIVILEGED_USERNS_ENABLED" == 0 ]] && echo '--no-sandbox')" "$@"


### PR DESCRIPTION
On Linux 5.11 and upstream versions the /proc/sys/kernel/unpriviledged_userns_clone is not available and the startup script just fails silently. This fixes it.