### PR TITLE
Searchable key configs

### DIFF
--- a/src/renderer/components/SearchKeyBox/SearchKeyBox.js
+++ b/src/renderer/components/SearchKeyBox/SearchKeyBox.js
@@ -337,6 +337,7 @@ class SearchKeyBox extends Component {
                 value={this.state.filter}
                 onChange={this.onFilterChange}
                 variant="outlined"
+                autoFocus
               />
               <Grid
                 container


### PR DESCRIPTION
# Feature
 - Closes #177 
 - Added a search box at the top of the key-config modal.
 - The search box automatically gets the focus.
 - When typing in the searchbox, only matching keys or groups are shown, according to the following rules:
    * Complete groups are shown if the `groupName` or `displayName` (case insensitively) contains the search string.
     * Partial groups are shown when there are keys in that group for which either the `primary` or `verbose` fields contain the search string.


# Screenshots
 - When first opening the search box
![image](https://user-images.githubusercontent.com/33070319/109560724-83596600-7adc-11eb-9198-5e305e535dbe.png)


 - Searching for a group name
![image](https://user-images.githubusercontent.com/33070319/109561205-227e5d80-7add-11eb-9f31-ec6a6497b982.png)



 - Searching for a specific key
![image](https://user-images.githubusercontent.com/33070319/109561325-4c378480-7add-11eb-856e-346be1f64fd7.png)