### PR TITLE
Fix for readability of dark theme

### DIFF
--- a/src/renderer/screens/FirmwareUpdate.js
+++ b/src/renderer/screens/FirmwareUpdate.js
@@ -83,13 +83,13 @@ const styles = theme => ({
   },
   snackVer: {
     fontSize: "1rem",
-    backgroundColor: "rgb(240,240,240);",
+    backgroundColor: "#2196F3",
     boxShadow: "none",
     placeContent: "center"
   },
   snackNot: {
     fontSize: "1rem",
-    backgroundColor: "antiquewhite",
+    backgroundColor: "#FF9800",
     boxShadow: "none",
     placeContent: "center",
     maxWidth: "none"
@@ -484,7 +484,7 @@ class FirmwareUpdate extends React.Component {
                           style={{
                             verticalAlign: "middle",
                             marginRight: "1rem",
-                            color: "orange"
+                            color: "white"
                           }}
                         />
                       </div>
@@ -544,7 +544,7 @@ class FirmwareUpdate extends React.Component {
                           style={{
                             verticalAlign: "middle",
                             marginRight: "1rem",
-                            color: "orange"
+                            color: "white"
                           }}
                         />
                       </div>
@@ -582,7 +582,7 @@ class FirmwareUpdate extends React.Component {
                         style={{
                           verticalAlign: "middle",
                           marginRight: "1rem",
-                          color: "dodgerblue"
+                          color: "white"
                         }}
                       />
                     </div>


### PR DESCRIPTION
Modified the background colors on the version info and firmware warnings to remove white text of very light backgrounds.

- Version info background set to light blue "info" color
- Firmware warning set to orange "warning" color
- icon images changed to white for contrast (matching existing font colors)

Signed-off-by:  Gareth Hancock <gazhank@gmail.com>