### PR TITLE
fix(search-key-box): prevent crashing when searching keys matching regex quantifiers

### DIFF
--- a/src/renderer/components/SearchKeyBox/SearchKeyBox.js
+++ b/src/renderer/components/SearchKeyBox/SearchKeyBox.js
@@ -132,7 +132,7 @@ function hasKeysInGroup(group) {
 }
 
 function containsSearchString(name, searchString) {
-  return name && new RegExp(searchString, "i").test(name);
+  return name && name.toLowerCase().includes(searchString.toLowerCase());
 }
 
 function filterKeysInGroup(group, filter) {


### PR DESCRIPTION
- Fixes #215

Tested locally with `build:linux`.