### PR TITLE
Add Unicode characters for keyboard symbols

### DIFF
--- a/src/api/keymap/db/ledeffects.js
+++ b/src/api/keymap/db/ledeffects.js
@@ -21,23 +21,25 @@ const LEDEffectsTable = {
     {
       code: 17152,
       labels: {
-        primary: "NEXT",
-        top: "LED"
+        primary: "+",
+        top: "✨",
+        verbose: "Next LED"
       }
     },
     {
       code: 17153,
       labels: {
-        primary: "PREV",
-        top: "LED",
-        verbose: "Previous"
+        primary: "-",
+        top: "✨",
+        verbose: "Previous LED"
       }
     },
     {
       code: 17154,
       labels: {
-        primary: "TOGGLE",
-        top: "LED"
+        primary: "+/-",
+        top: "✨",
+        verbose: "Toggle LED"
       }
     }
   ]

--- a/src/api/keymap/db/mediacontrols.js
+++ b/src/api/keymap/db/mediacontrols.js
@@ -22,14 +22,15 @@ const MediaControlTable = {
       code: 19682,
       labels: {
         top: "Media",
-        primary: "MUTE"
+        primary: "🔇",
+        verbose: "MUTE"
       }
     },
     {
       code: 22709,
       labels: {
         top: "Media",
-        primary: "TRACK+",
+        primary: "⏭",
         verbose: "Next track"
       }
     },
@@ -37,7 +38,7 @@ const MediaControlTable = {
       code: 22710,
       labels: {
         top: "Media",
-        primary: "TRACK-",
+        primary: "⏮",
         verbose: "Prev. track"
       }
     },
@@ -45,14 +46,15 @@ const MediaControlTable = {
       code: 22711,
       labels: {
         top: "Media",
-        primary: "STOP"
+        primary: "⏹",
+        verbose: "STOP"
       }
     },
     {
       code: 22733,
       labels: {
         top: "Media",
-        primary: "PLAY",
+        primary: "⏯",
         verbose: "Play / pause"
       }
     },
@@ -60,7 +62,7 @@ const MediaControlTable = {
       code: 23785,
       labels: {
         top: "Media",
-        primary: "VOL+",
+        primary: "🔊",
         verbose: "Volume up"
       }
     },
@@ -68,7 +70,7 @@ const MediaControlTable = {
       code: 23786,
       labels: {
         top: "Media",
-        primary: "VOL-",
+        primary: "🔉",
         verbose: "Volume down"
       }
     },
@@ -76,7 +78,8 @@ const MediaControlTable = {
       code: 22712,
       labels: {
         top: "Media",
-        primary: "Eject"
+        primary: "⏏",
+        verbose: "Eject"
       }
     }
   ]

--- a/src/api/keymap/db/miscellaneous.js
+++ b/src/api/keymap/db/miscellaneous.js
@@ -23,21 +23,22 @@ const MiscellaneousTable = {
     {
       code: 70,
       labels: {
-        primary: "PRINT SCREEN",
+        primary: "⎙",
         verbose: "Print Screen"
       }
     },
     {
       code: 71,
       labels: {
-        primary: "SCROLL LOCK",
+        primary: "⇳",
         verbose: "Scroll Lock"
       }
     },
     {
       code: 72,
       labels: {
-        primary: "PAUSE"
+        primary: "⎉",
+        verbose: "Pause / Break"
       }
     }
     /* These are disabled for now, since we don't want to display them in

--- a/src/api/keymap/db/modifiers.js
+++ b/src/api/keymap/db/modifiers.js
@@ -18,12 +18,33 @@
 import { withModifiers } from "./utils";
 
 const GuiLabels = {
+  linux: "LINUX",
+  win32: "WIN",
+  darwin: "⌘"
+};
+
+const GuiVerboses = {
   linux: "Linux",
-  win32: "Win",
-  darwin: "Cmd"
+  win32: "Windows",
+  darwin: "Command"
+};
+
+const AltLabels = {
+  linux: "ALT",
+  win32: "ALT",
+  darwin: "⌥"
+};
+
+const AltVerboses = {
+  linux: "Alt",
+  win32: "Alt",
+  darwin: "Option"
 };
 
 const guiLabel = GuiLabels[process.platform] || "Gui";
+const guiVerbose = GuiVerboses[process.platform] || "Gui";
+const AltLabel = AltLabels[process.platform] || "ALT";
+const AltVerbose = AltVerboses[process.platform] || "Alt";
 
 const ModifiersTable = {
   groupName: "Modifiers",
@@ -38,22 +59,22 @@ const ModifiersTable = {
     {
       code: 225,
       labels: {
-        primary: "LEFT SHIFT",
+        primary: "LEFT ⇧",
         verbose: "Left Shift"
       }
     },
     {
       code: 226,
       labels: {
-        primary: "LEFT ALT",
-        verbose: "Left Alt"
+        primary: "LEFT " + AltLabel,
+        verbose: "Left " + AltVerbose
       }
     },
     {
       code: 227,
       labels: {
-        primary: "LEFT " + guiLabel.toUpperCase(),
-        verbose: "Left " + guiLabel
+        primary: "LEFT " + guiLabel,
+        verbose: "Left " + guiVerbose
       }
     },
     {
@@ -67,7 +88,7 @@ const ModifiersTable = {
       code: 229,
       labels: {
         top: "",
-        primary: "RIGHT SHIFT",
+        primary: "RIGHT ⇧",
         verbose: "Right Shift"
       }
     },
@@ -75,15 +96,15 @@ const ModifiersTable = {
       code: 230,
       labels: {
         top: "",
-        primary: "RIGHT ALT",
+        primary: "RIGHT " + AltLabel,
         verbose: "AltGr"
       }
     },
     {
       code: 231,
       labels: {
-        primary: "RIGHT " + guiLabel.toUpperCase(),
-        verbose: "Right " + guiLabel
+        primary: "RIGHT " + guiLabel,
+        verbose: "Right " + guiVerbose
       }
     }
   ]

--- a/src/api/keymap/db/mousecontrols.js
+++ b/src/api/keymap/db/mousecontrols.js
@@ -22,28 +22,32 @@ const MouseMovementTable = {
       code: 20481,
       labels: {
         top: "Mouse",
-        primary: "UP"
+        primary: "↑",
+        verbose: "Mouse Up"
       }
     },
     {
       code: 20482,
       labels: {
         top: "Mouse",
-        primary: "DOWN"
+        primary: "↓",
+        verbose: "Mouse Down"
       }
     },
     {
       code: 20484,
       labels: {
         top: "Mouse",
-        primary: "LEFT"
+        primary: "←",
+        verbose: "Mouse Left"
       }
     },
     {
       code: 20488,
       labels: {
         top: "Mouse",
-        primary: "RIGHT"
+        primary: "→",
+        verbose: "Mouse Right"
       }
     }
   ]
@@ -56,28 +60,32 @@ const MouseWheelTable = {
       code: 20497,
       labels: {
         top: "M.Wheel",
-        primary: "UP"
+        primary: "↑",
+        verbose: "Mouse Wheel Up"
       }
     },
     {
       code: 20498,
       labels: {
         top: "M.Wheel",
-        primary: "DOWN"
+        primary: "↓",
+        verbose: "Mouse Wheel Down"
       }
     },
     {
       code: 20500,
       labels: {
         top: "M.Wheel",
-        primary: "LEFT"
+        primary: "←",
+        verbose: "Mouse Wheel Left"
       }
     },
     {
       code: 20504,
       labels: {
         top: "M.Wheel",
-        primary: "RIGHT"
+        primary: "→",
+        verbose: "Mouse Wheel Right"
       }
     }
   ]

--- a/src/api/keymap/db/navigation.js
+++ b/src/api/keymap/db/navigation.js
@@ -23,27 +23,29 @@ const NavigationTable = {
     {
       code: 75,
       labels: {
-        primary: "PAGE UP",
+        primary: "⇞",
         verbose: "Page Up"
       }
     },
     {
       code: 78,
       labels: {
-        primary: "PAGE DOWN",
+        primary: "⇟",
         verbose: "Page Down"
       }
     },
     {
       code: 74,
       labels: {
-        primary: "HOME"
+        primary: "⤒",
+        verbose: "HOME"
       }
     },
     {
       code: 77,
       labels: {
-        primary: "END"
+        primary: "⤓",
+        verbose: "END"
       }
     },
     {

--- a/src/api/keymap/db/punctuation.js
+++ b/src/api/keymap/db/punctuation.js
@@ -89,7 +89,7 @@ const PunctuationTable = {
     {
       code: 57,
       labels: {
-        primary: "CAPSLOCK",
+        primary: "⇪",
         verbose: "Caps Lock"
       }
     },

--- a/src/api/keymap/db/spacing.js
+++ b/src/api/keymap/db/spacing.js
@@ -23,44 +23,50 @@ const SpacingTable = {
     {
       code: 44,
       labels: {
-        primary: "SPACE"
+        primary: "␣",
+        verbose: "Space"
       }
     },
     {
       code: 40,
       labels: {
-        primary: "ENTER"
+        primary: "↵",
+        verbose: "Enter"
       }
     },
     {
       code: 43,
       labels: {
-        primary: "TAB"
+        primary: "↹",
+        verbose: "Tab"
       }
     },
     {
       code: 41,
       labels: {
-        primary: "ESC"
+        primary: "Esc",
+        verbose: "Escape"
       }
     },
     {
       code: 42,
       labels: {
-        primary: "BACKSPACE",
+        primary: "⌫",
         verbose: "Backspace"
       }
     },
     {
       code: 76,
       labels: {
-        primary: "DEL"
+        primary: "⌦",
+        verbose: "Delete"
       }
     },
     {
       code: 73,
       labels: {
-        primary: "INSERT"
+        primary: "⎀",
+        verbose: "Insert"
       }
     }
   ]

--- a/src/renderer/components/SearchKeyBox/GroupItem.js
+++ b/src/renderer/components/SearchKeyBox/GroupItem.js
@@ -24,6 +24,7 @@ import PropTypes from "prop-types";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
 import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
 import MultipleKeysGroup from "./MultipleKeysGroup";
 
 GroupItem.propTypes = {
@@ -125,13 +126,15 @@ function GroupItem(props) {
               className={classes.key}
               onClick={() => keySelect(code)}
             >
-              <Button
-                variant={code === selectedKeyCode ? "contained" : "outlined"}
-                color={code === selectedKeyCode ? "primary" : "default"}
-                className={classes.button}
-              >
-                {primary || (isTransparent(verbose) && "Transp.")}
-              </Button>
+              <Tooltip title={verbose || primary}>
+                <Button
+                  variant={code === selectedKeyCode ? "contained" : "outlined"}
+                  color={code === selectedKeyCode ? "primary" : "default"}
+                  className={classes.button}
+                >
+                  {primary || (isTransparent(verbose) && "Transp.")}
+                </Button>
+              </Tooltip>
             </Grid>
           ) : null}
         </React.Fragment>


### PR DESCRIPTION
Add unicode characters for common keyboard symbols.  Such as return, backspace etc.

_The intention of this change is to avoid using English words on the keyboard when unicode characters can be used.  Hopefully making the software more usable internationally, and avoiding long text strings which overflow the displayspace within the UI._

- Added unicode characters used to replace English language Key labels
- Verbose key labels are added so as to maintain readability, and maintain the key search function.  These should be updated in the future to use i18n, but hopefully this change is a step in the right direction for internationalisation.
- Additionally a tooltip (/mouse over) has been added to the GroupItem.js (key select screen) so that even if the icon is too small, or not known by the user, then the tooltip can explain the info.

I've broken down the changes into 4 commits to aid reviewing, since the 4 commits are all a little different in nature, and could be adopted individually if preferred. 

Examples:

Backspace, Return etc:
![image](https://user-images.githubusercontent.com/64541249/121746601-063b8500-cafe-11eb-971a-86eb358916a9.png)

Media Keys:
![image](https://user-images.githubusercontent.com/64541249/121746653-1d7a7280-cafe-11eb-95df-e8e50cf7c892.png)

Tooltip:
![image](https://user-images.githubusercontent.com/64541249/121746767-4864c680-cafe-11eb-930f-93c6fa85b03a.png)

Any comments of suggestions would be very welcome

Cheers

Gaz