### PR TITLE
Auto image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The primary purpose of the application is to allow one to configure their keyboa
 * **Firmware upgrade** to upload new versions of the firmware that ships with the application.
 
 ## Configuration
+
 Most of the preferences are saved to the keyboard itself, and changed in the UI, but some preferences are only available in config files. For example, if you don't want to automatically save a screenshot of the current layer before switching to a new layer, you can edit the file config.json to change "true" to "false" for that preference. This can be done while the application is running, without restart.
 
 ## Supported operating systems

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The primary purpose of the application is to allow one to configure their keyboa
 * **Colormap editor** to edit the per-key and underglow LED colormap.
 * **Firmware upgrade** to upload new versions of the firmware that ships with the application.
 
+## Configuration
+Most of the preferences are saved to the keyboard itself, and changed in the UI, but some preferences are only available in config files. For example, if you don't want to automatically save a screenshot of the current layer before switching to a new layer, you can edit the file config.json to change "true" to "false" for that preference. This can be done while the application is running, without restart.
+
+
 ## Supported operating systems
 
 Bazecor is supported on all three major operating systems, we test our releases on Windows 10, MacOS, and Ubuntu LTS.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The primary purpose of the application is to allow one to configure their keyboa
 ## Configuration
 Most of the preferences are saved to the keyboard itself, and changed in the UI, but some preferences are only available in config files. For example, if you don't want to automatically save a screenshot of the current layer before switching to a new layer, you can edit the file config.json to change "true" to "false" for that preference. This can be done while the application is running, without restart.
 
-
 ## Supported operating systems
 
 Bazecor is supported on all three major operating systems, we test our releases on Windows 10, MacOS, and Ubuntu LTS.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+    "saveScreenshotOnLayerChange": "true"
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "electron-updater": "^4.3.8",
     "electron-window-state": "^5.0.3",
     "firebase": "^8.4.1",
+    "html-to-image": "^1.7.0",
     "i18next": "^19.9.2",
     "i18next-electron-language-detector": "^0.0.10",
     "prop-types": "^15.7.2",

--- a/src/renderer/screens/Editor/Editor.js
+++ b/src/renderer/screens/Editor/Editor.js
@@ -181,7 +181,7 @@ class Editor extends Component {
     htmlToImage
       .toPng(el, { backgroundColor: "white" })
       .then(function (dataUrl) {
-        Editor.WriteImageFile(`layer${layerId}-temp`, dataUrl);
+        Editor.WriteImageFile(`layer${layerId}-temp.png`, dataUrl);
       })
       .catch(function (error) {
         console.error("oops, something went wrong!", error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6797,6 +6797,11 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
+html-to-image@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.7.0.tgz#4ca93bb90c0b9392edaafbfd5d94e8f0d666e18b"
+  integrity sha512-6egK8mOXMw82nLjj5g3ohERuzrTglgR9+Q6A2cqa7UiuSSKHuFxpABZJSfZztj0EdLC6tAePZJAhjPr4bbU9tw==
+
 html-webpack-plugin@^4.0.4:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"


### PR DESCRIPTION
Added functionality to automatically save screenshots of each layer when switching to another layer, unless the file config.json does not contain "saveScreenshotOnLayerChange": "true". The config.json can be edited while the application is running, and the setting will take effect on the next layer change.
The screenshots are saved to the same path as the execution path.
I was planning on adding more rich functionality (see #260 ), but this is good enough  for me - someone else can feel free to add frills, or I might add some later if I'm bored.