### PR TITLE
Added enter detection to close edit field for layer names

### DIFF
--- a/src/renderer/screens/Editor/LayerPanel.js
+++ b/src/renderer/screens/Editor/LayerPanel.js
@@ -161,6 +161,24 @@ export default class LayerPanel extends React.Component {
     this.spare = this.spare.bind(this);
   }
 
+  componentDidMount() {
+    document.addEventListener("keydown", this._handleKeyDown);
+  }
+
+  _handleKeyDown = event => {
+    switch (event.keyCode) {
+      case 13:
+        console.log("Enter key logged");
+        if (this.state.editCurrent == this.state.currentLayer) {
+          this.setState({ editCurrent: -1 });
+          this.upload();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
   spare() {
     console.log("disabled");
   }


### PR DESCRIPTION
This additional modification allows the user to close the editor field with an enter key when the focus is on the field.

Any thoughts on making this more obvious or adding any physical buttons to give the user more options?

Signed-off-by: AlexDygma <alex@dygma.com>