### PR TITLE
Adding hotkeys to Bazecor

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -122,6 +122,7 @@ class App extends React.Component {
 
     // Store all settings from electron settings in electron store.
     let data = {};
+    data.enableHotkeys = false;
     data.backupFolder =
       (await settings.get("backupFolder")) != undefined
         ? await settings.get("backupFolder")

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -51,6 +51,7 @@ const store = new Store();
 
 const { remote, ipcRenderer } = require("electron");
 const path = require("path");
+const fs = require("fs");
 
 let focus = new Focus();
 focus.debug = true;
@@ -79,7 +80,8 @@ class App extends React.Component {
       device: null,
       pages: {},
       contextBar: false,
-      cancelPendingOpen: false
+      cancelPendingOpen: false,
+      Hotkeys: {}
     };
     localStorage.clear();
 
@@ -154,6 +156,14 @@ class App extends React.Component {
         self.forceDarkMode(message);
       }
     });
+
+    // Loading Hotkey shortcuts file, if not, cretate
+    const HkFilePath = path.join(remote.app.getPath("home"), "Raise", "hotkeys.json");
+    if (fs.existsSync(HkFilePath)) {
+      this.setState({
+        Hotkeys: JSON.parse(fs.readFileSync(HkFilePath))
+      });
+    }
 
     usb.on("detach", async device => {
       if (!focus.device) return;
@@ -299,7 +309,7 @@ class App extends React.Component {
   };
 
   render() {
-    const { connected, pages, contextBar, darkMode } = this.state;
+    const { connected, pages, contextBar, darkMode, Hotkeys } = this.state;
 
     let focus = new Focus();
     let device =
@@ -346,6 +356,7 @@ class App extends React.Component {
               titleElement={() => document.querySelector("#page-title")}
               appBarElement={() => document.querySelector("#appbar")}
               darkMode={darkMode}
+              Hotkeys={Hotkeys}
             />
             <MacroEditor
               path="/macros"

--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -316,6 +316,7 @@ const English = {
     },
     advanced: "Advanced",
     verboseFocus: "Verbose logging",
+    hotkeys: "Enable Hotkeys",
     darkMode: {
       label: "Appearance",
       light: "Light",

--- a/src/renderer/modules/Settings/AdvancedSettings.js
+++ b/src/renderer/modules/Settings/AdvancedSettings.js
@@ -29,7 +29,7 @@ const Style = Styled.div`
 
 export default class AdvancedSettings extends Component {
   render() {
-    const { devToolsSwitch, verboseSwitch } = this.props;
+    const { devToolsSwitch, verboseSwitch, hotkeysSwitch } = this.props;
     return (
       <Style>
         <Card className="overflowFix card-preferences mt-4 mb-4">
@@ -47,6 +47,10 @@ export default class AdvancedSettings extends Component {
                   <Form.Group controlId="Verbose" className="switchHolder">
                     <Form.Label>{i18n.preferences.verboseFocus}</Form.Label>
                     {verboseSwitch}
+                  </Form.Group>
+                  <Form.Group controlId="Hotkeys" className="switchHolder">
+                    <Form.Label>{i18n.preferences.hotkeys}</Form.Label>
+                    {hotkeysSwitch}
                   </Form.Group>
                 </div>
               </Col>
@@ -122,5 +126,6 @@ class AdvancedKeyboardSettings extends React.Component {
 AdvancedSettings.propTypes = {
   devToolsSwitch: PropTypes.object.isRequired,
   verboseSwitch: PropTypes.object.isRequired,
+  hotkeysSwitch: PropTypes.object.isRequired,
   connected: PropTypes.bool.isRequired
 };

--- a/src/renderer/screens/Editor/LayerPanel.js
+++ b/src/renderer/screens/Editor/LayerPanel.js
@@ -156,17 +156,12 @@ export default class LayerPanel extends React.Component {
     this.ActOnClick = this.ActOnClick.bind(this);
     this.ExternalClick = this.ExternalClick.bind(this);
     this.LayerSel = this.LayerSel.bind(this);
-    this.updateText = this.updateText.bind(this);
     this.spare = this.spare.bind(this);
   }
 
-  componentDidMount() {
-    document.addEventListener("keydown", this._handleKeyDown);
-  }
+  componentDidMount() {}
 
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this._handleKeyDown);
-  }
+  componentWillUnmount() {}
 
   _handleKeyDown = event => {
     switch (event.keyCode) {
@@ -181,7 +176,8 @@ export default class LayerPanel extends React.Component {
         break;
       case 27:
         // ESC key
-        console.log("Esc key logged");
+        document.removeEventListener("keydown", this._handleKeyDown);
+        this.props.toggleKeydownListener();
         this.setState({
           editCurrent: -1,
           editorText: ""
@@ -226,10 +222,12 @@ export default class LayerPanel extends React.Component {
     );
   }
 
-  ActOnClick(id) {
+  ActOnClick = id => {
     let { currentLayer } = this.state;
 
     if (currentLayer == id) {
+      this.props.toggleKeydownListener();
+      document.addEventListener("keydown", this._handleKeyDown);
       this.setState({
         editCurrent: id,
         editorText: this.props.layers[id].name
@@ -237,7 +235,7 @@ export default class LayerPanel extends React.Component {
     } else {
       this.LayerSel(id);
     }
-  }
+  };
 
   ExternalClick() {
     let { currentLayer, editCurrent } = this.state;
@@ -251,9 +249,11 @@ export default class LayerPanel extends React.Component {
     }
   }
 
-  updateText(newText) {
+  updateText = newText => {
+    document.removeEventListener("keydown", this._handleKeyDown);
+    this.props.toggleKeydownListener();
     this.props.changeLayerName(newText);
-  }
+  };
 
   render() {
     const { isReadOnly, editCurrent } = this.state;

--- a/src/renderer/views/Preferences.js
+++ b/src/renderer/views/Preferences.js
@@ -90,7 +90,8 @@ class Preferences extends React.Component {
       selectedNeuron: 0,
       neuronID: "",
       kbData: this.kbData,
-      modified: props.inContext
+      modified: props.inContext,
+      hotkeys: store.get("settings.enableHotkeys")
     };
   }
 
@@ -357,6 +358,16 @@ class Preferences extends React.Component {
     }
   };
 
+  toggleHotkeys = event => {
+    if (event.target.checked) {
+      store.set("settings.enableHotkeys", true);
+      this.setState({ hotkeys: true });
+    } else {
+      store.set("settings.enableHotkeys", false);
+      this.setState({ hotkeys: false });
+    }
+  };
+
   // THEME MODE FUNCTIONS
   selectDarkMode = key => {
     this.setState({ darkMode: key });
@@ -403,9 +414,10 @@ class Preferences extends React.Component {
   };
 
   render() {
-    const { neurons, selectedNeuron, darkMode, neuronID, devTools, verboseFocus, kbData, modified } = this.state;
+    const { neurons, selectedNeuron, darkMode, neuronID, devTools, hotkeys, verboseFocus, kbData, modified } = this.state;
     const { inContext, connected } = this.props;
     const { defaultLayer } = this.kbData;
+    const hotkeysSwitch = <Form.Check type="switch" checked={hotkeys} onChange={this.toggleHotkeys} />;
     const devToolsSwitch = <Form.Check type="switch" checked={devTools} onChange={this.toggleDevTools} />;
     const verboseSwitch = <Form.Check type="switch" checked={verboseFocus} onChange={this.toggleVerboseFocus} />;
     // console.log("CHECKING STATUS MOD", modified);
@@ -446,7 +458,12 @@ class Preferences extends React.Component {
                     deleteNeuron={this.deleteNeuron}
                   />
                   <KeyboardSettings kbData={kbData} setKbData={this.setKbData} connected={connected} />
-                  <AdvancedSettings devToolsSwitch={devToolsSwitch} verboseSwitch={verboseSwitch} connected={connected} />
+                  <AdvancedSettings
+                    devToolsSwitch={devToolsSwitch}
+                    verboseSwitch={verboseSwitch}
+                    hotkeysSwitch={hotkeysSwitch}
+                    connected={connected}
+                  />
                 </Col>
               </Row>
             </Container>


### PR DESCRIPTION
Development of hotkeys feature for the different Bazecor editors.

The objective is to support a keymap that allows to create your own shortcut action for each key and editor in Bazecor.

Tasks:
- [x] Activation toggle in preferences to handle enable/disable the Hotkeys
- [ ] Event key down handler in the Layout editor
  - [x] Enable support for sub-event listeners in other modules
  - [x] Manage event listener activation on layer panel (that already uses keyboard shortcuts like enter, ESC and space)
  - [ ] Design and implement a parser for each mapped key in the Hotkeys.json file with each action
- [ ] Keydown event handler in Macros editor
- [ ] Keydown event handler in Superkeys editor

Signed-off-by: AlexDygma <alex@dygma.com>