### PR TITLE
Fixed NativeTheme exception by removing listener that could break on window close

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -95,9 +95,12 @@ async function createMainWindow() {
     window.show();
   });
 
-  nativeTheme.on("updated", function theThemeHasChanged() {
+  const theThemeHasChanged = () => {
     window.webContents.send("darkTheme-update", nativeTheme.shouldUseDarkColors);
-  });
+  };
+
+  nativeTheme.on("updated", theThemeHasChanged);
+
   const UiohookToName = Object.fromEntries(Object.entries(UiohookKey).map(([k, v]) => [v, k]));
 
   // function send webContents event for KeyDown
@@ -151,6 +154,7 @@ async function createMainWindow() {
   });
 
   window.on("closed", () => {
+    nativeTheme.off("updated", theThemeHasChanged);
     mainWindow = null;
   });
 


### PR DESCRIPTION
The error occured after exiting hibernation on mac, which means during the closing procedure of the window, the event listeners need to be removed as the JS is still active and the whole application isn't closed, this happens only on MAC

Signed-off-by: AlexDygma <alex@dygma.com>