### PR TITLE
Focus API doc update

### DIFF
--- a/FOCUS_API.md
+++ b/FOCUS_API.md
@@ -467,7 +467,7 @@ To retrieve:
 To set:
 
 - JavaScript: `focus.command("led.palete NNN NNN NNN NNN NNN NNN")`
-- Serial Command (Unix): `echo 'led.palette NNN NNN NNN NNN NNN NNN' > /dev/ttyACM0`
+- Serial Command (Unix): `echo 'palette NNN NNN NNN NNN NNN NNN' > /dev/ttyACM0`
 
 #### Expected output
 


### PR DESCRIPTION
Couldn't get the palette command to work with original syntax (led.palette). It did work with just 'palette'. Not sure if this also affects the javascript syntax, I wasn't able to test that.

Signed-off-by: Shawn Berg <bergshawnm@gmail.com>