### PR TITLE
Display the correct decimal separator on the German numpad

### DIFF
--- a/src/api/keymap/languages/german/german.js
+++ b/src/api/keymap/languages/german/german.js
@@ -102,6 +102,16 @@ const germanModifierKeys = [
   }
 ];
 
+const germanNumpad = [
+  {
+    code: 99,
+    labels: {
+      top: "Num",
+      primary: ","
+    }
+  }
+];
+
 const altCtrlGerman = {
   groupName: "AltCtrl German",
   keys: [
@@ -372,7 +382,7 @@ const shiftModifierGerman = {
   ]
 };
 
-const german = germanLetters.concat(germanModifierKeys);
+const german = germanLetters.concat(germanModifierKeys, germanNumpad);
 
 const table = { keys: german };
 const tableWithoutModifier = { keys: germanLetters };

--- a/src/renderer/components/Keyboard/GR.json
+++ b/src/renderer/components/Keyboard/GR.json
@@ -1704,7 +1704,7 @@
     "iconname": "",
     "content": {
       "type": "block",
-      "first": ".",
+      "first": ",",
       "second": "Del",
       "third": "",
       "fourth": ""

--- a/src/renderer/modules/KeyPickerKeyboard/GR.json
+++ b/src/renderer/modules/KeyPickerKeyboard/GR.json
@@ -1705,7 +1705,7 @@
     "iconname": "",
     "content": {
       "type": "block",
-      "first": ".",
+      "first": ",",
       "second": "Del",
       "third": "",
       "fourth": ""


### PR DESCRIPTION
As German uses `,` as the decimal separator, this also replaces the `.` on the German numpad (see https://en.wikipedia.org/wiki/German_keyboard_layout).

Signed-off-by: Tom Zöhner <8282547+zoehneto@users.noreply.github.com>