### PR TITLE
RGBW LED Palette support for Defy keyboards

### DIFF
--- a/src/api/color/RGBWtoRGB.js
+++ b/src/api/color/RGBWtoRGB.js
@@ -1,10 +1,9 @@
 export default function rgbw2b(rgbw) {
-  console.log("color received", rgbw);
   let r = rgbw.w + rgbw.r > 255 ? 255 : rgbw.w + rgbw.r;
   let g = rgbw.w + rgbw.g > 255 ? 255 : rgbw.w + rgbw.g;
   let b = rgbw.w + rgbw.b > 255 ? 255 : rgbw.w + rgbw.b;
 
-  let result = { r, g, b };
+  let result = `rgb(${r}, ${g}, ${b})`;
 
-  return result;
+  return { r, g, b, rgb: result };
 }

--- a/src/api/color/RGBWtoRGB.js
+++ b/src/api/color/RGBWtoRGB.js
@@ -1,0 +1,10 @@
+export default function rgbw2b(rgbw) {
+  console.log("color received", rgbw);
+  let r = rgbw.w + rgbw.r > 255 ? 255 : rgbw.w + rgbw.r;
+  let g = rgbw.w + rgbw.g > 255 ? 255 : rgbw.w + rgbw.g;
+  let b = rgbw.w + rgbw.b > 255 ? 255 : rgbw.w + rgbw.b;
+
+  let result = { r, g, b };
+
+  return result;
+}

--- a/src/api/color/RGBtoRGBW.js
+++ b/src/api/color/RGBtoRGBW.js
@@ -4,12 +4,12 @@ export default function rgb2w(rgb) {
   let Bi = rgb.b;
   let minVal = Math.min(Ri, Math.min(Gi, Bi));
 
-  let Wo = minVal;
-  let Bo = Bi - minVal;
-  let Ro = Ri - minVal;
-  let Go = Gi - minVal;
+  let w = minVal;
+  let b = Bi - minVal;
+  let r = Ri - minVal;
+  let g = Gi - minVal;
 
-  let result = { Ro, Go, Bo, Wo };
+  let result = { r, g, b, w };
 
   return result;
 }

--- a/src/api/color/RGBtoRGBW.js
+++ b/src/api/color/RGBtoRGBW.js
@@ -1,0 +1,15 @@
+export default function rgb2w(rgb) {
+  let Ri = rgb.r;
+  let Gi = rgb.g;
+  let Bi = rgb.b;
+  let minVal = Math.min(Ri, Math.min(Gi, Bi));
+
+  let Wo = minVal;
+  let Bo = Bi - minVal;
+  let Ro = Ri - minVal;
+  let Go = Gi - minVal;
+
+  let result = { Ro, Go, Bo, Wo };
+
+  return result;
+}

--- a/src/api/color/index.js
+++ b/src/api/color/index.js
@@ -1,0 +1,4 @@
+import rgb2w from "./RGBtoRGBW";
+import rgbw2b from "./RGBWtoRGB";
+
+export { rgb2w, rgbw2b };

--- a/src/api/colormap/index.js
+++ b/src/api/colormap/index.js
@@ -16,6 +16,7 @@
  */
 
 import Focus from "../focus";
+import { rgb2w, rgbw2b } from "../color";
 
 global.colormap_instance = null;
 
@@ -45,7 +46,6 @@ export default class Colormap {
   }
 
   setLEDMode(opts) {
-    console.log("PRINTING OPTS OF LED MODE", opts);
     if (!opts || opts == undefined) return;
 
     if (typeof opts == "number") {
@@ -90,12 +90,12 @@ export default class Colormap {
               .map(k => parseInt(k)),
             4
           ).map(color => {
+            const coloraux = rgbw2b({ r: color[0], g: color[1], b: color[2], w: color[3] });
             return {
-              r: color[0],
-              g: color[1],
-              b: color[2],
-              w: color[3],
-              rgbw: `rgbw(${color[0]}, ${color[1]}, ${color[2]}, ${color[3]})`
+              r: coloraux.r,
+              g: coloraux.g,
+              b: coloraux.b,
+              rgb: coloraux.rgb
             };
           });
 
@@ -118,10 +118,17 @@ export default class Colormap {
   }
 
   async _updatePalette(s, palette) {
-    let args =
-      this._LEDMode != "RGBW"
-        ? this._flatten(palette.map(color => [color.r, color.g, color.b])).map(v => v.toString())
-        : this._flatten(palette.map(color => [color.r, color.g, color.b, color.w])).map(v => v.toString());
+    let args;
+    if (this._LEDMode != "RGBW") {
+      args = this._flatten(palette.map(color => [color.r, color.g, color.b])).map(v => v.toString());
+    } else {
+      let paletteAux = palette.map(color => {
+        let aux = rgb2w({ r: color.r, g: color.g, b: color.b });
+        return aux;
+      });
+      args = this._flatten(paletteAux.map(color => [color.r, color.g, color.b, color.w])).map(v => v.toString());
+      console.log(palette, paletteAux, args);
+    }
 
     return await s.request("palette", ...args);
   }

--- a/src/api/hardware-dygma-defy-wired/components/Keymap.js
+++ b/src/api/hardware-dygma-defy-wired/components/Keymap.js
@@ -17,7 +17,6 @@
  */
 
 import React from "react";
-import rgbw2b from "../../color/RGBWtoRGB";
 import Neuron from "../../hardware/Neuron";
 import Key from "../../hardware/Key";
 import UnderGlowStrip from "../../hardware/UnderGlowStrip";
@@ -195,7 +194,7 @@ class KeymapDEFY extends React.Component {
       const colors = color.match(/\d+/g);
       if (colors == null || colors.length == 0) return "#000";
       let aux;
-      if ((colors[0] < 131 && colors[1] < 131) || (colors.length > 2 && colors[3] < 120)) {
+      if (colors[0] < 131 && colors[1] < 131) {
         aux = "#FFF";
       } else {
         aux = "#000";
@@ -238,11 +237,9 @@ class KeymapDEFY extends React.Component {
       let ledIndex = col !== undefined ? led_map[parseInt(row)][parseInt(col)] : no_key_led_map[row - UNDERGLOW];
       let colorIndex = colormap[ledIndex];
 
-      // console.log("testing colors", row, col, ledIndex, colorIndex, row - UNDERGLOW, this.props);
+      // console.log("testing colors", row, col, ledIndex, colorIndex, row - UNDERGLOW);
 
-      let color = palette[colorIndex].rgb != undefined ? palette[colorIndex].rgb : palette[colorIndex].rgbw;
-      if (color == "#ffffff") return color;
-      color = color.length > 3 ? rgbw2b(color) : color;
+      let color = palette[colorIndex].rgb;
       return color;
     };
 

--- a/src/api/hardware-dygma-defy-wired/components/Keymap.js
+++ b/src/api/hardware-dygma-defy-wired/components/Keymap.js
@@ -17,6 +17,7 @@
  */
 
 import React from "react";
+import rgbw2b from "../../color/RGBWtoRGB";
 import Neuron from "../../hardware/Neuron";
 import Key from "../../hardware/Key";
 import UnderGlowStrip from "../../hardware/UnderGlowStrip";
@@ -194,7 +195,7 @@ class KeymapDEFY extends React.Component {
       const colors = color.match(/\d+/g);
       if (colors == null || colors.length == 0) return "#000";
       let aux;
-      if (colors[0] < 131 && colors[1] < 131) {
+      if ((colors[0] < 131 && colors[1] < 131) || (colors.length > 2 && colors[3] < 120)) {
         aux = "#FFF";
       } else {
         aux = "#000";
@@ -237,9 +238,11 @@ class KeymapDEFY extends React.Component {
       let ledIndex = col !== undefined ? led_map[parseInt(row)][parseInt(col)] : no_key_led_map[row - UNDERGLOW];
       let colorIndex = colormap[ledIndex];
 
-      // console.log("testing colors", row, col, ledIndex, colorIndex, row - UNDERGLOW);
+      // console.log("testing colors", row, col, ledIndex, colorIndex, row - UNDERGLOW, this.props);
 
-      let color = palette[colorIndex].rgb;
+      let color = palette[colorIndex].rgb != undefined ? palette[colorIndex].rgb : palette[colorIndex].rgbw;
+      if (color == "#ffffff") return color;
+      color = color.length > 3 ? rgbw2b(color) : color;
       return color;
     };
 

--- a/src/api/hardware-dygma-defy-wired/index.js
+++ b/src/api/hardware-dygma-defy-wired/index.js
@@ -43,6 +43,7 @@ const Defy_wired = {
     rows: 2,
     columns: 89
   },
+  RGBWMode: true,
   components: {
     keymap: KeymapDEFY
   },

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -260,6 +260,7 @@ class App extends React.Component {
     console.log("Probing for Focus support...");
 
     focus.setLayerSize(focus.device);
+    focus.setLEDMode(focus.device);
     const pages = {
       keymap: focus.isCommandSupported("keymap.custom") || focus.isCommandSupported("keymap.map"),
       colormap: focus.isCommandSupported("colormap.map") && focus.isCommandSupported("palette")

--- a/src/renderer/component/ToggleButtons/KeyboardViewSelector.js
+++ b/src/renderer/component/ToggleButtons/KeyboardViewSelector.js
@@ -87,7 +87,6 @@ const Style = Styled.div`
 }
 `;
 const KeyboardViewSelector = ({ editModeFunc, value, listElements, style, size }) => {
-  console.log("Data from props", value, listElements);
   return (
     // className={`button-config ${value == item.value ? "active" : ""}`}
     <Style className={`toggleButtonsContainer ${style == "flex" ? "toggleButtonsContainerFlex" : ""}`}>

--- a/src/renderer/component/ToggleButtons/ToggleButtons.js
+++ b/src/renderer/component/ToggleButtons/ToggleButtons.js
@@ -45,7 +45,6 @@ const Style = Styled.div`
 }
 `;
 const ToggleButtons = ({ selectDarkMode, value, listElements, style, size }) => {
-  console.log("Data from props", value, listElements);
   return (
     // className={`button-config ${value == item.value ? "active" : ""}`}
     <Style className={`toggleButtonsContainer ${style == "flex" ? "toggleButtonsContainerFlex" : ""}`}>

--- a/src/renderer/modules/ColorEditor/ColorEditor.js
+++ b/src/renderer/modules/ColorEditor/ColorEditor.js
@@ -116,7 +116,6 @@ export default class ColorEditor extends Component {
 
   handleChange(color) {
     const { selected, onColorPick } = this.props;
-    console.log(selected, color);
     onColorPick(selected, color.rgb.r, color.rgb.g, color.rgb.b);
   }
 
@@ -138,7 +137,6 @@ export default class ColorEditor extends Component {
 
   selectColor(ev, pick) {
     const { colors, selected, onColorSelect } = this.props;
-    console.log(colors[pick], pick, selected);
     onColorSelect(pick);
     if (pick === selected) {
       // setIndexFocusButton(!indexFocusButton);

--- a/src/renderer/modules/KeyVisualizer/KeyVisualizer.js
+++ b/src/renderer/modules/KeyVisualizer/KeyVisualizer.js
@@ -81,10 +81,10 @@ const Style = Styled.div`
             text-transform: uppercase;
             color: ${({ theme }) => theme.styles.keyVisualizer.colorSuperkeyAction};
             font-weight: 600;
-          } 
+          }
       }
       .keySelectedBox {
-          padding: 8px 16px;   
+          padding: 8px 16px;
           border: 2px solid ${({ theme }) => theme.styles.keyVisualizer.borderOldValue};
           box-shadow: none;
           width: 104px;

--- a/src/renderer/modules/NavigationMenu/NavigationMenu.js
+++ b/src/renderer/modules/NavigationMenu/NavigationMenu.js
@@ -168,7 +168,7 @@ class NavigationMenu extends Component {
   }
 
   compareFWVer(oldVer, newVer) {
-    console.log("comparing versions ", oldVer, newVer);
+    // console.log("comparing versions ", oldVer, newVer);
     if (oldVer.length != newVer.length) {
       if (oldVer.length > newVer.length) {
         return -1;

--- a/src/renderer/views/LayoutEditor.js
+++ b/src/renderer/views/LayoutEditor.js
@@ -893,28 +893,6 @@ class LayoutEditor extends React.Component {
     this.props.cancelContext();
   };
 
-  onApplyDefy = async () => {
-    this.setState({ saving: true });
-    let focus = new Focus();
-    await focus.command("keymap", this.state.keymap);
-    await focus.command("colormap", this.state.palette, this.state.colorMap);
-    this.setState({
-      modified: false,
-      saving: false,
-      previousKeyIndex: this.state.currentKeyIndex,
-      previousLedIndex: this.state.currentLedIndex,
-      previousLayer: this.state.currentLayer,
-      isMultiSelected: false,
-      selectedPaletteColor: null,
-      isColorButtonSelected: false
-    });
-    console.log("Changes saved.");
-    const commands = await this.bkp.Commands();
-    const backup = await this.bkp.DoBackup(commands, this.state.neurons[this.state.neuronID].id);
-    this.bkp.SaveBackup(backup);
-    this.props.cancelContext();
-  };
-
   // Callback function to set State of new Language
   onChangeLanguageLayout = () => {
     console.log("Language automatically set to: ", store.get("settings.language"));


### PR DESCRIPTION
The following changes allow the defy to share it's palette in RGBW format so that colors can be stored in the keyboard as already converted to make use of the extended color gamut we can achieve with the additional white LED

further improvement to this library includes a color correction to take into account the color temperature of each LED that is used on the Defy, but that depend on the final units of the manufacturing batch, so it will be added afterwards.