### PR TITLE
Fixed a typo in dual function description

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -250,7 +250,7 @@ const English = {
         descriptionModifiers: "Add any of these modifiers to selected key to create combinations such as Control, Alt or Shift.",
         addDualFunction: "Add a dual-function",
         dualFunctionDescription:
-          "Dual-function keys have two functionalities. 1. When tapped, they send a chartacter. 2. When held, they send a modifier o a layer key."
+          "Dual-function keys have two functionalities. 1. When tapped, they send a chartacter. 2. When held, they send a modifier or a Shift to layer key."
       },
       layers: {
         title: "Layers",


### PR DESCRIPTION
Saw this typo mentioned in the discord _bug-and-issues_ section and decided to fix it as my first contribution to this project.

Side note: Not sure if "Shift" should be capitalised here (that's how _Dygman_ suggested it). Feel free to adjust or give me a nudge and I'll do it