### PR TITLE
Use "universal" architecture for mac build

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,7 @@
       "category": "productivity",
       "target": {
         "target": "default",
-        "arch": [
-          "arm64",
-          "x64"
-        ]
+        "arch": "universal"
       },
       "type": "distribution",
       "darkModeSupport": true,


### PR DESCRIPTION
Electron allows to combine the build files for x64 and arm64 in one dmg file. The file will be bigger, but work natively on intel and m1 macs.

* see https://github.com/electron/universal
* see https://www.electronjs.org/blog/apple-silicon#what-do-i-need-to-do

closes #362 