### PR TITLE
fixed toExport() to handle new return of showSaveDialogSync() -  changed from electron@13.6.9 to electron@18.3.7

### DIFF
--- a/src/renderer/views/LayoutEditor.js
+++ b/src/renderer/views/LayoutEditor.js
@@ -1529,10 +1529,10 @@ class LayoutEditor extends React.Component {
     };
 
     try {
-      const resp = await ipcRenderer.invoke("save-dialog", options);
-      if (!resp.canceled) {
-        console.log(resp.filePath, data);
-        require("fs").writeFileSync(resp.filePath, data);
+      const path = await ipcRenderer.invoke("save-dialog", options);
+      if (typeof path !== "undefined") {
+        console.log(path, data);
+        require("fs").writeFileSync(path, data);
         toast.success(
           <ToastMessage
             title={i18n.editor.exportSuccessCurrentLayer}
@@ -1587,10 +1587,10 @@ class LayoutEditor extends React.Component {
     };
 
     try {
-      const resp = await ipcRenderer.invoke("save-dialog", options);
-      if (!resp.canceled) {
-        console.log(resp.filePath, data);
-        require("fs").writeFileSync(resp.filePath, data);
+      const path = await ipcRenderer.invoke("save-dialog", options);
+      if (typeof path !== "undefined") {
+        console.log(path, data);
+        require("fs").writeFileSync(path, data);
         toast.success(
           <ToastMessage
             title={i18n.editor.exportSuccessAllLayers}


### PR DESCRIPTION
the returntype of  showSaveDialogSync() changed somewhere between these electron versions.
according to the documentation it now returns a string. [link](https://www.electronjs.org/docs/latest/api/dialog#dialogshowsavedialogsyncbrowserwindow-options)