### PR TITLE
Remove allowRendererProcessReuse workaround

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,10 +26,6 @@ import { Environment } from "./dragons";
 // [1]: https://github.com/electron-userland/electron-webpack/issues/275
 process.env[`NODE_ENV`] = Environment.name;
 
-// This is a workaround for the lack of context-awareness in two native modules
-// we use, serialport (serialport/node-serialport#2051) and usb
-// (tessel/node-usb#380). See electron/electron#18397 for more context.
-app.allowRendererProcessReuse = false;
 app.disableHardwareAcceleration();
 if (process.platform !== "darwin") {
   app.commandLine.appendSwitch("high-dpi-support", 1);


### PR DESCRIPTION
Per the referenced issues for the affected modules, both have since been patched and this workaround should no longer be required