### PR TITLE
Fix deprecated Node.js version in GitHub action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
-        uses: samuelmeuli/action-electron-builder@v1
+        uses: coparse-inc/action-electron-builder@v1.0.0
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)


### PR DESCRIPTION
`samuelmeuli/action-electron-builder@v1` used in the `build` GitHub action uses a deprecated version 12 of Node.js. The repository doesn't seem to be maintained anymore ([https://github.com/samuelmeuli/action-electron-builder/issues/87](https://github.com/samuelmeuli/action-electron-builder/issues/87)), but there is another updated [source](https://github.com/marketplace/actions/macro-electron-builder-action) for the same action. This PR switches to the updated source.