### PR TITLE
Fix typo

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -401,7 +401,7 @@ const English = {
         mediaTitle: "Media",
         mediaDescription: "Skip boring songs, turn the sound louder. <br>Harder, better, faster, stronger!",
         LEDTitle: "LED",
-        LEDDescrition: "Turn the RBG lighting On or Off and control the cycle through the lights effects.",
+        LEDDescription: "Turn the RGB lighting On or Off and control the cycle through the lights effects.",
         othersTitle: "Others",
         othersDescription: "Control your media, apps and brightness. Safe and sound!"
       }

--- a/src/renderer/modules/KeysTabs/MediaAndLightTab.js
+++ b/src/renderer/modules/KeysTabs/MediaAndLightTab.js
@@ -179,7 +179,7 @@ class MediaAndLightTab extends Component {
             </div>
             <div className="LEDButtons">
               <Title text={i18n.editor.superkeys.specialKeys.LEDTitle} headingLevel={4} />
-              <p className="description">{i18n.editor.superkeys.specialKeys.LEDDescrition}</p>
+              <p className="description">{i18n.editor.superkeys.specialKeys.LEDDescription}</p>
               <div className="keysButtonsList">
                 <ButtonConfig
                   buttonText={i18n.editor.superkeys.specialKeys.ledToggleText}


### PR DESCRIPTION
Fix a typo in the UI: "RBG" -> "RGB".
Fix a typo in the Javascript: "Descrition" -> "Description".