### PR TITLE
Setting USE_HARD_LINKS and pushing electron builder version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-2019
             gyp: ""
           - os: ubuntu-20.04
-            gyp: use_udev=0 use_system_libusb=true
+            gyp: use_udev=0 use_system_libusb=true USE_HARD_LINKS=false
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-2019
             gyp: ""
           - os: ubuntu-20.04
-            gyp: use_udev=0 use_system_libusb=true USE_HARD_LINKS=false
+            gyp: use_udev=0 use_system_libusb=true
 
     steps:
       - name: Check out Git repository
@@ -49,6 +49,7 @@ jobs:
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+          USE_HARD_LINKS: false
         uses: coparse-inc/action-electron-builder@v1.0.0
         with:
           # GitHub token, automatically provided to the action

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@svgr/webpack": "^6.2.1",
     "babel-loader": "^8.2.2",
     "electron": "^18.3.7",
-    "electron-builder": "^24.0.0",
+    "electron-builder": "^23.0.2",
     "electron-notarize": "^1.0.0",
     "electron-webpack": "^2.8.2",
     "electron-webpack-eslint": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@svgr/webpack": "^6.2.1",
     "babel-loader": "^8.2.2",
     "electron": "^18.3.7",
-    "electron-builder": "^23.0.2",
+    "electron-builder": "^24.0.0",
     "electron-notarize": "^1.0.0",
     "electron-webpack": "^2.8.2",
     "electron-webpack-eslint": "^6.0.0",


### PR DESCRIPTION
Testing configurations to avoid issues with GitHub actions without affecting all the compilation runs at the same time 