### PR TITLE
Disabled the restoration of layer names, etc... to limit it to kb data

### DIFF
--- a/src/renderer/modules/Settings/BackupSettings.js
+++ b/src/renderer/modules/Settings/BackupSettings.js
@@ -118,11 +118,11 @@ export default class BackupSettings extends Component {
       data = backup;
     } else {
       data = backup.backup;
-      // TODO: IF THE USER WANTS!!
-      let neurons = this.props.neurons;
-      let index = neurons.findIndex(n => n.id == this.props.neuronID);
-      neurons[index] = backup.neuron;
-      store.set("neurons", neurons);
+      // TODO: IF THE USER WANTS!! --> Until this can be chosen, disabling this behaviour
+      // let neurons = this.props.neurons;
+      // let index = neurons.findIndex(n => n.id == this.props.neuronID);
+      // neurons[index] = backup.neuron;
+      // store.set("neurons", neurons);
     }
     try {
       for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
Issues could arise if the Neuron configuration of the backup you want to restore is going to erase the names you changed, or any other issue related to this topic.

The backup restoration view requires an opt-in process to select exactly what do you want to restore, until that screen is ready, we are disabling this functionality.