### PR TITLE
Fixed errors in Norwegian, Danish, Icelandic and Swedish layouts when modifying keys

### DIFF
--- a/src/api/keymap/languages/danish/danish.js
+++ b/src/api/keymap/languages/danish/danish.js
@@ -362,7 +362,7 @@ const shiftModifierDanish = {
 
 const danish = danishLetters.concat(danishModifierKeys);
 
-const table = { keys: danishModifierKeys };
+const table = { keys: danish };
 const tableWithoutModifier = { keys: danishLetters };
 
 const danishCtrlTable = withModifiers(table, "Control +", "C+", 256);

--- a/src/api/keymap/languages/icelandic/icelandic.js
+++ b/src/api/keymap/languages/icelandic/icelandic.js
@@ -369,7 +369,7 @@ const shiftModifierIcelandic = {
 
 const icelandic = icelandicLetters.concat(icelandicModifierKeys);
 
-const table = { keys: icelandicModifierKeys };
+const table = { keys: icelandic };
 const tableWithoutModifier = { keys: icelandicLetters };
 
 const icelandicCtrlTable = withModifiers(table, "Control +", "C+", 256);

--- a/src/api/keymap/languages/norwegian/norwegian.js
+++ b/src/api/keymap/languages/norwegian/norwegian.js
@@ -350,7 +350,7 @@ const shiftModifierNorwegian = {
 
 const norwegian = norwegianLetters.concat(norwegianModifierKeys);
 
-const table = { keys: norwegianModifierKeys };
+const table = { keys: norwegian };
 const tableWithoutModifier = { keys: norwegianLetters };
 
 const norwegianCtrlTable = withModifiers(table, "Control +", "C+", 256);

--- a/src/api/keymap/languages/swedish/swedish.js
+++ b/src/api/keymap/languages/swedish/swedish.js
@@ -362,7 +362,7 @@ const shiftModifierSwedish = {
 
 const swedish = swedishLetters.concat(swedishModifierKeys);
 
-const table = { keys: swedishModifierKeys };
+const table = { keys: swedish };
 const tableWithoutModifier = { keys: swedishLetters };
 
 const swedishCtrlTable = withModifiers(table, "Control +", "C+", 256);


### PR DESCRIPTION
Several layouts had problems due to using only the modified keys table to calculate the variants when applying modifiers to them, instead of the junction of letters and modified keys which is the way to go to maintain all symbols the same when applying those modifiers