### PR TITLE
Fixed default layer loading when onlyCustom is selected

### DIFF
--- a/src/renderer/views/LayoutEditor.js
+++ b/src/renderer/views/LayoutEditor.js
@@ -616,7 +616,7 @@ class LayoutEditor extends React.Component {
       }
 
       // console.log("KEYMAP TEST!!", keymap, keymap.onlyCustom, onlyC);
-      if (empty && !keymap.onlyCustom && keymap.custom.length > 0) {
+      if (empty && keymap.custom.length > 0) {
         console.log("Custom keymap is empty, copying defaults");
         for (let i = 0; i < keymap.default.length; i++) {
           keymap.custom[i] = keymap.default[i].slice();


### PR DESCRIPTION
The Default layers were not being loaded properly when the keyboard was erased, the problem is related to the onlyCustom flag.