### PR TITLE
feat: added UG slider to control brightness

### DIFF
--- a/src/renderer/i18n/en.js
+++ b/src/renderer/i18n/en.js
@@ -502,8 +502,9 @@ const English = {
     },
     led: {
       title: "LED",
-      brightness: "LED brightness",
+      brightness: "LED backlight brightness",
       brightnesssub: " - From 0 to 254",
+      brightnessUG: "LED underglow brightness",
       idleDisabled: "Disabled",
       idleTimeLimit: "Time before LEDs turn off",
       idle: {

--- a/src/renderer/modules/Settings/KeyboardSettings.js
+++ b/src/renderer/modules/Settings/KeyboardSettings.js
@@ -230,6 +230,15 @@ class KeyboardSettings extends React.Component {
     }));
     this.props.setKbData(this.state);
   };
+
+  setBrightnessUG = async value => {
+    await this.setState(state => ({
+      ledBrightnessUG: (value * 255) / 100,
+      modified: true
+    }));
+    this.props.setKbData(this.state);
+  };
+
   setHoldTimeout = async value => {
     await this.setState(state => ({
       qukeysHoldTimeout: value,
@@ -424,6 +433,7 @@ class KeyboardSettings extends React.Component {
       modified,
       showDefaults,
       ledBrightness,
+      ledBrightnessUG,
       ledIdleTimeLimit,
       qukeysHoldTimeout,
       qukeysOverlapThreshold,
@@ -562,6 +572,32 @@ class KeyboardSettings extends React.Component {
                           step={5}
                           value={Math.round((ledBrightness * 100) / 255)}
                           onChange={this.setBrightness}
+                        />
+                      </Col>
+                      <Col xs={2} md={1} className="p-0 text-center align-self-center">
+                        <span className="tagsfix">Max</span>
+                      </Col>
+                    </Row>
+                  </Form.Group>
+                )}
+                {ledBrightnessUG >= 0 && (
+                  <Form.Group controlId="brightnessUGControl" className="formGroup">
+                    <Row>
+                      <Col>
+                        <Form.Label>{i18n.keyboardSettings.led.brightnessUG}</Form.Label>
+                      </Col>
+                    </Row>
+                    <Row>
+                      <Col xs={2} md={1} className="p-0 text-center align-self-center">
+                        <span className="tagsfix">None</span>
+                      </Col>
+                      <Col xs={8} md={10} className="px-2">
+                        <Slider
+                          min={0}
+                          max={100}
+                          step={5}
+                          value={Math.round((ledBrightnessUG * 100) / 255)}
+                          onChange={this.setBrightnessUG}
                         />
                       </Col>
                       <Col xs={2} md={1} className="p-0 text-center align-self-center">

--- a/src/renderer/views/Preferences.js
+++ b/src/renderer/views/Preferences.js
@@ -62,6 +62,7 @@ class Preferences extends React.Component {
         onlyCustom: true
       },
       ledBrightness: 255,
+      ledBrightnessUG: 255,
       defaultLayer: 126,
       ledIdleTimeLimit: 0,
       qukeysHoldTimeout: 0,
@@ -142,6 +143,11 @@ class Preferences extends React.Component {
     await focus.command("led.brightness").then(brightness => {
       brightness = brightness ? parseInt(brightness) : -1;
       this.kbData.ledBrightness = brightness;
+    });
+
+    await focus.command("led.brightnessUG").then(brightness => {
+      brightness = brightness ? parseInt(brightness) : -1;
+      this.kbData.ledBrightnessUG = brightness;
     });
 
     await focus.command("idleleds.time_limit").then(limit => {
@@ -274,11 +280,6 @@ class Preferences extends React.Component {
       await focus.command("wireless.rf.stability").then(rfStability => {
         this.kbData.wireless.rf.stability = rfStability;
       });
-
-      // Additional commands
-      await focus.command("led.brightness.underglow").then(UGBrightness => {
-        this.kbData.ledBrightnessUG = UGBrightness;
-      });
     }
 
     //Save in state
@@ -293,6 +294,7 @@ class Preferences extends React.Component {
       defaultLayer,
       showDefaults,
       ledBrightness,
+      ledBrightnessUG,
       ledIdleTimeLimit,
       qukeysHoldTimeout,
       qukeysOverlapThreshold,
@@ -308,13 +310,13 @@ class Preferences extends React.Component {
       mouseWheelSpeed,
       mouseWheelDelay,
       mouseSpeedLimit,
-      wireless,
-      ledBrightnessUG
+      wireless
     } = this.kbData;
 
     await await focus.command("keymap.onlyCustom", keymap.onlyCustom);
     await await focus.command("settings.defaultLayer", defaultLayer);
     await await focus.command("led.brightness", ledBrightness);
+    await await focus.command("led.brightnessUG", ledBrightnessUG);
     if (ledIdleTimeLimit >= 0) await await focus.command("idleleds.time_limit", ledIdleTimeLimit);
     store.set("settings.showDefaults", showDefaults);
     // QUKEYS
@@ -348,7 +350,6 @@ class Preferences extends React.Component {
       await await focus.command("wireless.rf.channelHop", wireless.rf.channelHop);
       await await focus.command("wireless.rf.state", wireless.rf.state);
       await await focus.command("wireless.rf.stability", wireless.rf.stability);
-      await await focus.command("led.brightness.underglow", ledBrightnessUG);
     }
 
     //TODO: Review toast popup on try/catch works well.


### PR DESCRIPTION
This feature allows the user to change the brightness independently for the keys backlight and the underglow, which will allow them to save battery in the wireless version and also match the LED intensity of each group to the user preference.

This is compatible with both the Raise stable FW and the new Defy product lineup, Raise beta will be soon integrated on the stable branch for the Raise.