### PR TITLE
fix: sides now flash without instabilities

### DIFF
--- a/src/renderer/controller/FlashingSM/FWSelection.js
+++ b/src/renderer/controller/FlashingSM/FWSelection.js
@@ -8,7 +8,7 @@ const FocusAPIRead = async () => {
   let data = {};
   try {
     let focus = new Focus();
-    data.bootloader = focus.device.bootloader;
+    data.bootloader = focus.device ? focus.device.bootloader : false;
     data.info = focus.device.info;
     if (data.bootloader) return data;
     data.version = await focus.command("version");


### PR DESCRIPTION
When updating the Sides, there was flashing instability and the process could fail.

- [x] Add more time between flashing blocks 
- [x] Add re-tries system to continue the process and solve bad blocks
- [x] Get final validation and check the result