### PR TITLE
fix: tabIdex was missing for discard/save buttons

### DIFF
--- a/src/renderer/component/Button/regularButton.js
+++ b/src/renderer/component/Button/regularButton.js
@@ -18,7 +18,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const RegularButton = ({ selected, onClick, size, buttonText, style, icoSVG, icoPosition, disabled }) => {
+const RegularButton = ({ selected, onClick, size, buttonText, style, icoSVG, icoPosition, disabled, tabIndex }) => {
   return (
     <div
       onClick={disabled ? () => {} : onClick}
@@ -26,6 +26,7 @@ const RegularButton = ({ selected, onClick, size, buttonText, style, icoSVG, ico
         icoPosition ? icoPosition : "None"
       }`}
       disabled={disabled}
+      tabIndex={tabIndex}
     >
       <div className={"buttonLabel"}>
         {icoSVG && icoPosition !== "right" ? icoSVG : ""}

--- a/src/renderer/modules/KeyPickerKeyboard/KeyPickerReduced.js
+++ b/src/renderer/modules/KeyPickerKeyboard/KeyPickerReduced.js
@@ -480,7 +480,7 @@ class KeyPickerReduced extends Component {
           icony={key.icony}
           iconsize={key.iconsize}
           disabled={key.mod == disableMods || key.move == disableMove || disableAll}
-          // disabled={false}
+          tabIndex={-1}
           idArray={key.idArray}
           keyCode={code}
         />

--- a/src/renderer/modules/Saving/Saving.js
+++ b/src/renderer/modules/Saving/Saving.js
@@ -27,6 +27,7 @@ const Saving = ({ saveContext, destroyContext, inContext }) => {
   return (
     <Style className="savingButtons">
       <RegularButton
+        tabIndex={0}
         onClick={destroyContext}
         buttonText={i18n.app.cancelPending.button}
         style="outline"
@@ -34,6 +35,7 @@ const Saving = ({ saveContext, destroyContext, inContext }) => {
         disabled={!inContext}
       />
       <RegularButton
+        tabIndex={0}
         onClick={saveContext}
         buttonText={i18n.components.save.button}
         style="primary"


### PR DESCRIPTION
Tabindex was missing from the discard and save actions, now they are included in the order of the top bar elements as they should