### PR TITLE
Add EurKEY language support (and other language improvements)

### DIFF
--- a/src/renderer/modules/KeyPickerKeyboard/KeyPickerReduced.js
+++ b/src/renderer/modules/KeyPickerKeyboard/KeyPickerReduced.js
@@ -41,22 +41,23 @@ import {
   AiOutlineForward,
 } from "react-icons/ai";
 import { MdKeyboardReturn, MdSpaceBar, MdKeyboardCapslock, MdInfoOutline, MdEject } from "react-icons/md";
-import i18n from "../../i18n";
 
-import Key from "./Key";
-import ES from "./ES.json";
-import ENi from "./ENi.json";
-import ENa from "./ENa.json";
-import GR from "./GR.json";
-import FR from "./FR.json";
-import SW from "./SW.json";
-import DN from "./DN.json";
-import NW from "./NW.json";
-import IC from "./IC.json";
-import JP from "./JP.json";
-import KR from "./KR.json";
-import SWGR from "./SWGR.json";
-import EU from "./EU.json";
+import i18n from "@Renderer/i18n";
+
+import Key from "@Renderer/modules/KeyPickerKeyboard/Key";
+import ES from "@Renderer/modules/KeyPickerKeyboard/ES.json";
+import ENi from "@Renderer/modules/KeyPickerKeyboard/ENi.json";
+import ENa from "@Renderer/modules/KeyPickerKeyboard/ENa.json";
+import GR from "@Renderer/modules/KeyPickerKeyboard/GR.json";
+import FR from "@Renderer/modules/KeyPickerKeyboard/FR.json";
+import SW from "@Renderer/modules/KeyPickerKeyboard/SW.json";
+import DN from "@Renderer/modules/KeyPickerKeyboard/DN.json";
+import NW from "@Renderer/modules/KeyPickerKeyboard/NW.json";
+import IC from "@Renderer/modules/KeyPickerKeyboard/IC.json";
+import JP from "@Renderer/modules/KeyPickerKeyboard/JP.json";
+import KR from "@Renderer/modules/KeyPickerKeyboard/KR.json";
+import SWGR from "@Renderer/modules/KeyPickerKeyboard/SWGR.json";
+import EU from "@Renderer/modules/KeyPickerKeyboard/EU.json";
 // import SelectSuperKeys from "../../component/Select/SelectSuperKey";
 
 const Style = Styled.div`
@@ -326,18 +327,18 @@ class KeyPickerReduced extends Component {
     };
     let Lang = ENa;
 
-    if (selectedlanguage == "english") {
-      if (kbtype == "ansi") {
-        if (lansi[selectedlanguage] != undefined) {
+    if (selectedlanguage === "english") {
+      if (kbtype === "ansi") {
+        if (lansi[selectedlanguage] !== undefined) {
           Lang = lansi[selectedlanguage];
         }
       } else {
         Lang = liso[selectedlanguage];
       }
-    } else if (selectedlanguage != "") {
-      if (liso[selectedlanguage] != undefined) {
+    } else if (selectedlanguage !== "") {
+      if (liso[selectedlanguage] !== undefined) {
         Lang = liso[selectedlanguage];
-      } else if (lansi[selectedlanguage] != undefined) {
+      } else if (lansi[selectedlanguage] !== undefined) {
         Lang = lansi[selectedlanguage];
       }
     }


### PR DESCRIPTION
- Add [EurKEY](https://eurkey.steffen.bruentjen.eu/) 1.3 language support
  - Use lowercase a-z as default, shift renders A-Z
  - Use AltGr letters and symbols together with Meh/Hyper, displaying AltGr (with/without shift) layers instead of a-z
  - Add a new 1US (1U Square) key to support grouping of four letters in a square
- Add support for language names e.g. "Swiss (German)" and "EurKEY (1.3)" instead of SwissGerman and Eurkey
- Trimmed off some whitespace
- Remove korean from ISO layout (it's an ANSI layout)
- Re-work language select to support multiple ANSI layout
- Add support for korean in Standard view

![Screenshot 2023-08-01 094501](https://github.com/Dygmalab/Bazecor/assets/3641536/9a686889-4a4b-4c44-ae79-681706279f69)

![Screenshot 2023-08-01 104749](https://github.com/Dygmalab/Bazecor/assets/3641536/0a1fb837-827e-49a7-8b3f-b9c48b37c48f)