### PR TITLE
fix: removing of ble devices when upgrade

### DIFF
--- a/src/api/flash/defyFlasher/NRf52833-flasher.js
+++ b/src/api/flash/defyFlasher/NRf52833-flasher.js
@@ -230,14 +230,19 @@ const NRf52833 = {
 
     //ERASE device
     func_array.push(function (callback) {
-      write_cb(str2ab("E" + num2hexstr(dataObjects[0].address, 8) + "#"), callback);
+      const lastAddres = dataObjects[dataObjects.length-1].address;
+      const sizeHex = lastAddres - (lastAddres%1024)+1024;
+      write_cb(
+          str2ab(`E${num2hexstr(dataObjects[0].address, 8)},${num2hexstr(sizeHex, 8)}#`),
+          callback
+      );
     });
     func_array.push(callback => {
       read_cb(callback);
     });
 
     var state = 1,
-      stateT = 50;
+        stateT = 50;
     while (total > 0) {
       let bufferSize = total < PACKET_SIZE ? total : PACKET_SIZE;
 


### PR DESCRIPTION
Right now the upgrade was removing all the memory of the N2 just added a few lines to just remove the hex content + 1024 bytes