### PR TITLE
Fix udev rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Bazecor",
   "productName": "Bazecor",
-  "version": "1.3.5",
+  "version": "1.3.6-rc.1",
   "description": "Bazecor desktop app",
   "private": true,
   "repository": {

--- a/src/main/utils/udev.ts
+++ b/src/main/utils/udev.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import * as sudo from "sudo-prompt";
 
 const udevRulesToWrite =
-  'SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2201", GROUP="users", MODE="0666"\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", GROUP="users", MODE="0666"\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="35EF", MODE="0666"';
+  'SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2201", MODE="0666"\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", MODE="0666"\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="35EF", MODE="0666"\nKERNEL=="hidraw*", ATTRS{idVendor}=="35EF", MODE="0666"';
 
 const filename = "/etc/udev/rules.d/10-dygma.rules";
 


### PR DESCRIPTION
Udev rules were having erratic behavior as reported by other users, this fix removes the group filter as it's not needed (already using mode 666) and added hid rules to enable the usage of HID mode in Bluetooth when it becomes available.