### PR TITLE
Fix Defy FW version filter on FirmwareFlasher view

### DIFF
--- a/src/renderer/controller/FlashingSM/FWSelection.js
+++ b/src/renderer/controller/FlashingSM/FWSelection.js
@@ -52,7 +52,7 @@ const loadAvailableFirmwareVersions = async allowBeta => {
         });
         // console.log([asset.name, asset.browser_download_url]);
       });
-      // console.log(newRelease);
+      console.log(newRelease);
       if (allowBeta || !newRelease.version.includes("beta")) {
         Releases.push(newRelease);
       }
@@ -75,8 +75,11 @@ const GitHubRead = async context => {
     finalReleases = fwReleases.filter(
       release =>
         release.name === context.device.info.product &&
-        (context.device.info.product === "Defy" ? SemVer.satisfies(release.version, FWMAJORVERSION) : true),
+        (context.device.info.product === "Defy"
+          ? SemVer.satisfies(release.version, FWMAJORVERSION, { includePrerelease: true })
+          : true),
     );
+    console.log("FINAL RELEASES", finalReleases);
     finalReleases.sort((a, b) => (SemVer.lt(SemVer.clean(a.version), SemVer.clean(b.version)) ? 1 : -1));
     if (context.device.bootloader) return { firmwareList: finalReleases, isUpdated: false, isBeta: false };
     isUpdated = context.device.version === finalReleases[0].version;

--- a/src/renderer/controller/FlashingSM/FWSelection.js
+++ b/src/renderer/controller/FlashingSM/FWSelection.js
@@ -52,7 +52,7 @@ const loadAvailableFirmwareVersions = async allowBeta => {
         });
         // console.log([asset.name, asset.browser_download_url]);
       });
-      console.log(newRelease);
+      // console.log(newRelease);
       if (allowBeta || !newRelease.version.includes("beta")) {
         Releases.push(newRelease);
       }
@@ -79,7 +79,6 @@ const GitHubRead = async context => {
           ? SemVer.satisfies(release.version, FWMAJORVERSION, { includePrerelease: true })
           : true),
     );
-    console.log("FINAL RELEASES", finalReleases);
     finalReleases.sort((a, b) => (SemVer.lt(SemVer.clean(a.version), SemVer.clean(b.version)) ? 1 : -1));
     if (context.device.bootloader) return { firmwareList: finalReleases, isUpdated: false, isBeta: false };
     isUpdated = context.device.version === finalReleases[0].version;


### PR DESCRIPTION
The semver.satisfies check was not comparing only version numbers but also exlcuded pre-release versions from being compared, so a flag was added to include them