### PR TITLE
fix: changed modified report to avoid rerender of MacroEditor

### DIFF
--- a/src/renderer/views/MacroEditor.jsx
+++ b/src/renderer/views/MacroEditor.jsx
@@ -279,12 +279,16 @@ class MacroEditor extends React.Component {
   // Define updateActions function to update the actions of the selected macro
   updateActions = actions => {
     const { startContext } = this.props;
-    const { macros, selectedMacro } = this.state;
+    const { macros, selectedMacro, modified } = this.state;
 
     const macrosList = macros;
     macrosList[selectedMacro].actions = actions;
-    this.setState({ macros: macrosList, modified: true });
-    startContext();
+    if (!modified) {
+      this.setState({ macros: macrosList, modified: true });
+      startContext();
+    } else {
+      this.setState({ macros: macrosList });
+    }
   };
 
   saveName = data => {


### PR DESCRIPTION
Avoided calling startContext function when not necessary to avoid rerender of MacroEditor view.