### PR TITLE
fix: increased contrast of scrollbar on macro timeline editor

### DIFF
--- a/src/renderer/modules/Macros/TimelineEditorMacroTable.js
+++ b/src/renderer/modules/Macros/TimelineEditorMacroTable.js
@@ -57,18 +57,25 @@ const Styles = Styled.div`
 &.trackingWrapper {
     position: relative;
     z-index: 1;
-    
+
     background-color: ${({ theme }) => theme.styles.macro.trackingBackground};
     overflow-x: hidden;
     position: relative;
     > div {
       width: inherit;
-      overflow-x: auto; 
+      overflow-x: auto;
       padding-left: 32px;
+      ::-webkit-scrollbar-track {
+        -webkit-box-shadow: transparent;
+        background-color: white;
+      }
+      ::-webkit-scrollbar-thumb {
+        background-color: grey;
+      }
     }
 }
 .timelinetracking {
-    display: flex; 
+    display: flex;
     flex-wrap: nowrap;
     flex-direction: row;
     width: fit-content;


### PR DESCRIPTION
Scrollbar was too dark on dark mode and gave out no clue to the user of it's presence, now it's better defined