### PR TITLE
Enable debug without console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,6 @@ out/
 dist
 
 #editor's configuration
-.vscode
 .idea
 /test-results/
 /playwright-report/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Electron Main",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.sh",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
+      },
+      // runtimeArgs will be passed directly to your Electron application
+      "runtimeArgs": [
+          ".",
+          // this args for attaching render process
+          "--remote-debugging-port=9222"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach to Render Process",
+      "port": 9222,
+      "webRoot": "${workspaceRoot}/html"
+    }
+  ]
+}


### PR DESCRIPTION
Now any Linux user will have access to the renderer logs without having to use the integrated chrome console, as it's bugged on electron for that O.S. as soon as Electron patches this or a solution is found, we will enable the console again.