### PR TITLE
fix: removed no-sandbox for bazecor on linux as video wasn't rendering 

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,10 +15,6 @@ if (require("electron-squirrel-startup")) {
   app.quit();
 }
 
-if (process.platform === "linux") {
-  app.commandLine.appendSwitch("no-sandbox");
-}
-
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.


### PR DESCRIPTION
No sandbox mode was the culprit and only affected Linux, this was introduced on the migration to Forge and caused errors since!