### PR TITLE
fix: changed drag response when using wireless energy modal

### DIFF
--- a/src/renderer/component/Modal/AdvancedBatterySettingsModal.tsx
+++ b/src/renderer/component/Modal/AdvancedBatterySettingsModal.tsx
@@ -67,7 +67,14 @@ function AdvancedBatterySettingsModal(props: AdvancedEnergyManagementProps) {
   };
 
   return (
-    <Modal size="xl" show={showModal} onHide={() => setShowModal(false)} aria-labelledby="contained-modal-title-vcenter" centered>
+    <Modal
+      size="xl"
+      show={showModal}
+      onHide={() => setShowModal(false)}
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+      backdrop="static"
+    >
       <Modal.Header closeButton>
         <Modal.Title>{i18n.wireless.energyManagement.advancedSettings}</Modal.Title>
       </Modal.Header>


### PR DESCRIPTION
Added backdrop="static" tag to prevent default behaviour when clicking outside wireless advanced settings (energy) modal so that drag actions that go out of bounds do not close it