### PR TITLE
fix: github Actions now required to use Python >= 3.8 on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,17 +63,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        id: SetupPython
+        with:
+          python-version: "3.10"
+      - run: pipx run --python '${{ steps.SetupPython.outputs.python-path }}' nox --version
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0
       - run: npm install -g yarn
       - if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install libudev-dev
-      - if: runner.os == 'Windows'
-        name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - if: runner.os == 'Windows'
         name: Set up Java
         uses: actions/setup-java@v3
@@ -91,6 +91,8 @@ jobs:
       - if: runner.os == 'Windows'
         name: Setup GCloud Auth
         uses: "google-github-actions/auth@v1"
+        env:
+          CLOUDSDK_PYTHON: ${{ steps.SetupPython.outputs.python-path }}
         with:
           credentials_json: "${{ secrets.GCP_SIGNER_SERVICE_ACCOUNT }}"
       - if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         name: Setup GCloud Auth
         uses: "google-github-actions/auth@v1"
         env:
-          CLOUDSDK_PYTHON: ${{ steps.SetupPython.outputs.python-path }}
+          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
         with:
           credentials_json: "${{ secrets.GCP_SIGNER_SERVICE_ACCOUNT }}"
       - if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         id: SetupPython
         with:
           python-version: "3.10"
-      - run: pipx run --python '${{ steps.SetupPython.outputs.python-path }}' nox --version
+      - run: echo '${{ steps.SetupPython.outputs.python-version }}'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
       - if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install libudev-dev
       - if: runner.os == 'Windows'
+        name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - if: runner.os == 'Windows'
         name: Set up Java
         uses: actions/setup-java@v3
         with:
@@ -113,7 +118,7 @@ jobs:
           APPLE_INSTALLER_CERT_PATH=$RUNNER_TEMP/apple_installer.p12
           APPLE_APPLICATION_CERT_PATH=$RUNNER_TEMP/apple_application.p12
           KEYCHAIN_PATH=$RUNNER_TEMP/apple-signing.keychain-db
-          # create certificates from base64 
+          # create certificates from base64
           echo -n "$APPLE_INSTALLER_CERT_BASE64" | base64 --decode -o $APPLE_INSTALLER_CERT_PATH
           echo -n "$APPLE_APPLICATION_CERT_BASE64" | base64 --decode -o $APPLE_APPLICATION_CERT_PATH
           # create keychain stuff
@@ -122,9 +127,9 @@ jobs:
           security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           #import certificates
           echo "Importing installer cert"
-          security import $APPLE_INSTALLER_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH 
+          security import $APPLE_INSTALLER_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           echo "Importing application cert"
-          security import $APPLE_APPLICATION_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH 
+          security import $APPLE_APPLICATION_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
           # - run: yarn run lint
       - if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
+          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64\python' }}
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
       - if: runner.os == 'Windows'
         name: Setup GCloud Auth
         uses: "google-github-actions/auth@v1"
-        env:
-          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
         with:
           credentials_json: "${{ secrets.GCP_SIGNER_SERVICE_ACCOUNT }}"
       - if: runner.os == 'Windows'
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
+        env:
+          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         id: SetupPython
         with:
           python-version: "3.10"
-      - run: echo '${{ steps.SetupPython.outputs.python-version }}'
+      - run: echo '"${{ env.pythonLocation }}${{ '\\python' }}"'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64\python' }}
+          CLOUDSDK_PYTHON: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,17 +63,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        id: SetupPython
-        with:
-          python-version: "3.10"
-      - run: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0
       - run: npm install -g yarn
       - if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install libudev-dev
+      - if: runner.os == 'Windows'
+        name: SetupPython
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - if: runner.os == 'Windows'
         name: Set up Java
         uses: actions/setup-java@v3
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
+          CLOUDSDK_PYTHON: ${{ env.pythonLocation }}${{ '\python' }}
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         id: SetupPython
         with:
           python-version: "3.10"
-      - run: echo '"${{ env.pythonLocation }}${{ '\\python' }}"'
+      - run: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -63,17 +63,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        id: SetupPython
+        with:
+          python-version: "3.10"
+      - run: pipx run --python '${{ steps.SetupPython.outputs.python-path }}' nox --version
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0
       - run: npm install -g yarn
       - if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install libudev-dev
-      - if: runner.os == 'Windows'
-        name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - if: runner.os == 'Windows'
         name: Set up Java
         uses: actions/setup-java@v3
@@ -91,6 +91,8 @@ jobs:
       - if: runner.os == 'Windows'
         name: Setup GCloud Auth
         uses: "google-github-actions/auth@v1"
+        env:
+          CLOUDSDK_PYTHON: ${{ steps.SetupPython.outputs.python-path }}
         with:
           credentials_json: "${{ secrets.GCP_SIGNER_SERVICE_ACCOUNT }}"
       - if: runner.os == 'Windows'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -92,7 +92,7 @@ jobs:
         name: Setup GCloud Auth
         uses: "google-github-actions/auth@v1"
         env:
-          CLOUDSDK_PYTHON: ${{ steps.SetupPython.outputs.python-path }}
+          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
         with:
           credentials_json: "${{ secrets.GCP_SIGNER_SERVICE_ACCOUNT }}"
       - if: runner.os == 'Windows'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: "${{ env.pythonLocation }}${{ '\\python' }}"
+          CLOUDSDK_PYTHON: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -67,7 +67,7 @@ jobs:
         id: SetupPython
         with:
           python-version: "3.10"
-      - run: echo '${{ steps.SetupPython.outputs.python-version }}'
+      - run: echo '"${{ env.pythonLocation }}${{ '\\python' }}"'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64\python' }}
+          CLOUDSDK_PYTHON: "${{ env.pythonLocation }}${{ '\\python' }}"
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -67,7 +67,7 @@ jobs:
         id: SetupPython
         with:
           python-version: "3.10"
-      - run: pipx run --python '${{ steps.SetupPython.outputs.python-path }}' nox --version
+      - run: echo '${{ steps.SetupPython.outputs.python-version }}'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -70,6 +70,11 @@ jobs:
       - if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install libudev-dev
       - if: runner.os == 'Windows'
+        name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - if: runner.os == 'Windows'
         name: Set up Java
         uses: actions/setup-java@v3
         with:
@@ -113,7 +118,7 @@ jobs:
           APPLE_INSTALLER_CERT_PATH=$RUNNER_TEMP/apple_installer.p12
           APPLE_APPLICATION_CERT_PATH=$RUNNER_TEMP/apple_application.p12
           KEYCHAIN_PATH=$RUNNER_TEMP/apple-signing.keychain-db
-          # create certificates from base64 
+          # create certificates from base64
           echo -n "$APPLE_INSTALLER_CERT_BASE64" | base64 --decode -o $APPLE_INSTALLER_CERT_PATH
           echo -n "$APPLE_APPLICATION_CERT_BASE64" | base64 --decode -o $APPLE_APPLICATION_CERT_PATH
           # create keychain stuff
@@ -122,9 +127,9 @@ jobs:
           security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           #import certificates
           echo "Importing installer cert"
-          security import $APPLE_INSTALLER_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH 
+          security import $APPLE_INSTALLER_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           echo "Importing application cert"
-          security import $APPLE_APPLICATION_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH 
+          security import $APPLE_APPLICATION_CERT_PATH -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
           # - run: yarn run lint
       - if: runner.os == 'macOS'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
+          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64\python' }}
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -91,13 +91,13 @@ jobs:
       - if: runner.os == 'Windows'
         name: Setup GCloud Auth
         uses: "google-github-actions/auth@v1"
-        env:
-          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
         with:
           credentials_json: "${{ secrets.GCP_SIGNER_SERVICE_ACCOUNT }}"
       - if: runner.os == 'Windows'
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
+        env:
+          CLOUDSDK_PYTHON: ${{ 'C:\hostedtoolcache\windows\Python\3.10.11\x64' }}
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -63,17 +63,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        id: SetupPython
-        with:
-          python-version: "3.10"
-      - run: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0
       - run: npm install -g yarn
       - if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install libudev-dev
+      - if: runner.os == 'Windows'
+        name: SetupPython
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - if: runner.os == 'Windows'
         name: Set up Java
         uses: actions/setup-java@v3
@@ -97,7 +97,7 @@ jobs:
         name: "Set up GCloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
         env:
-          CLOUDSDK_PYTHON: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
+          CLOUDSDK_PYTHON: ${{ env.pythonLocation }}${{ '\python' }}
         with:
           version: ">= 416.0.0"
       - name: Cache node_modules

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -67,7 +67,7 @@ jobs:
         id: SetupPython
         with:
           python-version: "3.10"
-      - run: echo '"${{ env.pythonLocation }}${{ '\\python' }}"'
+      - run: echo '"${{ env.pythonLocation }}${{ '\python' }}"'
       - uses: actions/setup-node@v3
         with:
           node-version: 18.16.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Bazecor",
   "productName": "Bazecor",
-  "version": "1.3.6",
+  "version": "1.3.7-rc.1",
   "description": "Bazecor desktop app",
   "private": true,
   "repository": {


### PR DESCRIPTION
Added compilation support for new library of GCloud that requires Python > 3.7 (which apparently we were using)