### PR TITLE
fix: superkeys when copied had linked actions and mods affected all

### DIFF
--- a/src/renderer/views/SuperkeysEditor.js
+++ b/src/renderer/views/SuperkeysEditor.js
@@ -195,6 +195,7 @@ class SuperkeysEditor extends React.Component {
     const aux = { ...superkeys[selectedSuper] };
     aux.id = superkeys.length;
     aux.name = `Copy of ${aux.name}`;
+    aux.actions = [...aux.actions];
     superkeys.push(aux);
     this.updateSuper(superkeys, -1);
     this.changeSelected(aux.id);


### PR DESCRIPTION
created an actions array copy when copying the superkey in the duplicate procedure