### PR TITLE
build(dist): compute and publish released assets checksums

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -26,6 +26,11 @@ module.exports = {
             path: "@semantic-release/exec",
             cmd: "mv dist/*.AppImage dist/bazecor-v${nextRelease.version}.AppImage",
           },
+          {
+            path: "@semantic-release/exec",
+            cmd: "sha256sum * > sha256sums.txt",
+            execCwd: "dist",
+          },
         ],
         assets: [
           {
@@ -43,6 +48,10 @@ module.exports = {
           {
             path: "dist/bazecor-v${nextRelease.version}.AppImage",
             name: "bazecor-v${nextRelease.version}.AppImage",
+          },
+          {
+            path: "dist/sha256sums.txt",
+            name: "sha256sums.txt",
           },
         ],
       },


### PR DESCRIPTION
This PR simply add sha256 checksums to the release so:
- users can verify their download
- external packagers can easily include them or update them without downloading it all

I've seen #568, would you accept PR contributing packaging/publication for some dist (like adding an AUR package publication for archlinux to the release process) ?