### PR TITLE
Superkeys - Layer Shift, Modifiers and help section in Standard View

### DIFF
--- a/src/renderer/modules/KeysTabs/KeysTab.js
+++ b/src/renderer/modules/KeysTabs/KeysTab.js
@@ -28,7 +28,7 @@ h4 {
     flex: 0 0 100%;
 }
 .groupButtons {
-  padding: 0; 
+  padding: 0;
 }
 .cardButtons .groupButtons .button-config {
   padding: 8px 2px;
@@ -54,7 +54,7 @@ h4 {
       border-bottom-right-radius: 0;
       padding: 8px 16px;
       h4 {
-        font-size: 14px; 
+        font-size: 14px;
         margin-top: 2px;
         margin-bottom: 2px;
       }
@@ -104,7 +104,7 @@ class KeysTab extends Component {
             keyCode={keyCode}
             disableMove={false}
             // disableMods={false}
-            disableMods={!!((superkeyAction === 0 || superkeyAction === 3) && actTab === "super")}
+            disableMods={!!((superkeyAction == 0 || superkeyAction == 3) && actTab === "super")}
             // disableMove={![0, 3].includes(actions) && actTab == "super"}
             actTab={actTab}
             superName="superName"
@@ -113,7 +113,7 @@ class KeysTab extends Component {
           />
           {isStandardView ? (
             <div
-              className={`enhanceKeys ${(superkeyAction === 0 || superkeyAction === 3) && actTab === "super" ? "disabled" : ""}`}
+              className={`enhanceKeys ${(superkeyAction == 0 || superkeyAction == 3) && actTab === "super" ? "disabled" : ""}`}
             >
               <Title
                 text={i18n.editor.standardView.keys.enhanceTitle}

--- a/src/renderer/modules/KeysTabs/LayersTab.js
+++ b/src/renderer/modules/KeysTabs/LayersTab.js
@@ -48,7 +48,7 @@ class LayersTab extends Component {
   }
 
   render() {
-    const { keyCode, isStandardView, showLayerSwitch, actTab } = this.props;
+    const { keyCode, isStandardView, actTab } = this.props;
     const layerDeltaSwitch = 17450;
     const layerDelta = 17492;
     return (
@@ -66,84 +66,82 @@ class LayersTab extends Component {
               videoDuration="6:50"
             />
           ) : null}
-          {showLayerSwitch ? (
-            <div className="cardButtons">
-              <Title text={i18n.editor.standardView.layers.layerSwitch} headingLevel={4} />
-              <p>{i18n.editor.standardView.layers.layerSwitchDescription}</p>
-              <div className="groupButtons">
-                <ButtonConfig
-                  buttonText="1"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 0);
-                  }}
-                  selected={layerDeltaSwitch + 0 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="2"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 1);
-                  }}
-                  selected={layerDeltaSwitch + 1 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="3"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 2);
-                  }}
-                  selected={layerDeltaSwitch + 2 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="4"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 3);
-                  }}
-                  selected={layerDeltaSwitch + 3 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="5"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 4);
-                  }}
-                  selected={layerDeltaSwitch + 4 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="6"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 5);
-                  }}
-                  selected={layerDeltaSwitch + 5 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="7"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 6);
-                  }}
-                  selected={layerDeltaSwitch + 6 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="8"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 7);
-                  }}
-                  selected={layerDeltaSwitch + 7 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="9"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 8);
-                  }}
-                  selected={layerDeltaSwitch + 8 == keyCode}
-                />
-                <ButtonConfig
-                  buttonText="10"
-                  onClick={() => {
-                    this.props.onLayerPress(layerDeltaSwitch + 9);
-                  }}
-                  selected={layerDeltaSwitch + 9 == keyCode}
-                />
-              </div>
+          <div className="cardButtons">
+            <Title text={i18n.editor.standardView.layers.layerSwitch} headingLevel={4} />
+            <p>{i18n.editor.standardView.layers.layerSwitchDescription}</p>
+            <div className="groupButtons">
+              <ButtonConfig
+                buttonText="1"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 0);
+                }}
+                selected={layerDeltaSwitch + 0 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="2"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 1);
+                }}
+                selected={layerDeltaSwitch + 1 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="3"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 2);
+                }}
+                selected={layerDeltaSwitch + 2 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="4"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 3);
+                }}
+                selected={layerDeltaSwitch + 3 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="5"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 4);
+                }}
+                selected={layerDeltaSwitch + 4 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="6"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 5);
+                }}
+                selected={layerDeltaSwitch + 5 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="7"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 6);
+                }}
+                selected={layerDeltaSwitch + 6 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="8"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 7);
+                }}
+                selected={layerDeltaSwitch + 7 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="9"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 8);
+                }}
+                selected={layerDeltaSwitch + 8 == keyCode}
+              />
+              <ButtonConfig
+                buttonText="10"
+                onClick={() => {
+                  this.props.onLayerPress(layerDeltaSwitch + 9);
+                }}
+                selected={layerDeltaSwitch + 9 == keyCode}
+              />
             </div>
-          ) : null}
+          </div>
           <div className="cardButtons">
             <Title text={i18n.editor.layers.layerLock} headingLevel={4} />
             <p>

--- a/src/renderer/modules/KeysTabs/LayersTab.js
+++ b/src/renderer/modules/KeysTabs/LayersTab.js
@@ -23,6 +23,10 @@ h4 {
 .cardButtons .groupButtons .button-config {
   padding: 8px 2px;
   width: 40px;
+
+  &[disabled] {
+    pointer-events: none;
+  }
 }
 .tabContentWrapper {
   width: 100%;
@@ -48,7 +52,7 @@ class LayersTab extends Component {
   }
 
   render() {
-    const { keyCode, isStandardView, actTab } = this.props;
+    const { keyCode, isStandardView, actTab, disableMods } = this.props;
     const layerDeltaSwitch = 17450;
     const layerDelta = 17492;
     return (
@@ -76,6 +80,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 0);
                 }}
                 selected={layerDeltaSwitch + 0 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="2"
@@ -83,6 +88,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 1);
                 }}
                 selected={layerDeltaSwitch + 1 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="3"
@@ -90,6 +96,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 2);
                 }}
                 selected={layerDeltaSwitch + 2 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="4"
@@ -97,6 +104,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 3);
                 }}
                 selected={layerDeltaSwitch + 3 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="5"
@@ -104,6 +112,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 4);
                 }}
                 selected={layerDeltaSwitch + 4 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="6"
@@ -111,6 +120,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 5);
                 }}
                 selected={layerDeltaSwitch + 5 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="7"
@@ -118,6 +128,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 6);
                 }}
                 selected={layerDeltaSwitch + 6 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="8"
@@ -125,6 +136,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 7);
                 }}
                 selected={layerDeltaSwitch + 7 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="9"
@@ -132,6 +144,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 8);
                 }}
                 selected={layerDeltaSwitch + 8 == keyCode}
+                disabled={disableMods}
               />
               <ButtonConfig
                 buttonText="10"
@@ -139,6 +152,7 @@ class LayersTab extends Component {
                   this.props.onLayerPress(layerDeltaSwitch + 9);
                 }}
                 selected={layerDeltaSwitch + 9 == keyCode}
+                disabled={disableMods}
               />
             </div>
           </div>

--- a/src/renderer/modules/StandardView/StandardView.js
+++ b/src/renderer/modules/StandardView/StandardView.js
@@ -217,7 +217,6 @@ const Styles = Styled.div`
         margin-top: 0;
       }
     }
-    
   }
 }
 
@@ -366,7 +365,6 @@ export default class StandardView extends React.Component {
                       <LayersTab
                         onLayerPress={onKeySelect}
                         keyCode={keyCode}
-                        showLayerSwitch={actTab !== "super"}
                         isStandardView={isStandardView}
                         actTab={actTab}
                       />

--- a/src/renderer/modules/StandardView/StandardView.js
+++ b/src/renderer/modules/StandardView/StandardView.js
@@ -367,6 +367,7 @@ export default class StandardView extends React.Component {
                         keyCode={keyCode}
                         isStandardView={isStandardView}
                         actTab={actTab}
+                        disableMods={!!((keyIndex == 0 || keyIndex == 3) && actTab === "super")}
                       />
                     </Tab.Pane>
                     <Tab.Pane eventKey="tabMacro">

--- a/src/renderer/modules/Superkeys/SuperKeysFeatures.js
+++ b/src/renderer/modules/Superkeys/SuperKeysFeatures.js
@@ -61,7 +61,7 @@ h5 {
             height:16px;
             left: -26px;
             background-color: transparent;
-            background-image: url(${IconCheckmarkSm}); 
+            background-image: url(${IconCheckmarkSm});
         }
     }
 }
@@ -106,7 +106,7 @@ function SuperKeysFeatures() {
                         <li className="active">Media & LED</li>
                         <li className="active">Mouse</li>
                         <li className="active">Layer Lock</li>
-                        <li>Layer Shift</li>
+                        <li className="active">Layer Shift</li>
                         <li>Dual-function</li>
                         <li>OneShot</li>
                         <li>Superkeys</li>
@@ -121,7 +121,7 @@ function SuperKeysFeatures() {
                         <li className="active">Media & LED</li>
                         <li className="active">Mouse</li>
                         <li className="active">Layer Lock</li>
-                        <li>Layer Shift</li>
+                        <li className="active">Layer Shift</li>
                         <li>Dual-function</li>
                         <li>OneShot</li>
                         <li>Superkeys</li>
@@ -151,7 +151,7 @@ function SuperKeysFeatures() {
                         <li className="active">Media & LED</li>
                         <li className="active">Mouse</li>
                         <li className="active">Layer Lock</li>
-                        <li>Layer Shift</li>
+                        <li className="active">Layer Shift</li>
                         <li>Dual-function</li>
                         <li>OneShot</li>
                         <li>Superkeys</li>


### PR DESCRIPTION
- You could only enable **Layer Shift** on Superkeys on **Single View**, it where missing on **Standard View**.
- **Standard View** could use modifiers on Tap-actions.
- Updated "documentation" (help section).

`keyIndex` is an string, so other `===` and `!==` are failing as well, but will let you guys handle those. Or convert it into an integer/number.