### PR TITLE
Macro recorder now parses keyboard input matching the configured language

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Bazecor",
   "productName": "Bazecor",
-  "version": "1.3.9",
+  "version": "1.3.10-rc.1",
   "description": "Bazecor desktop app",
   "private": true,
   "repository": {

--- a/src/renderer/modules/Macros/MacroCreator.js
+++ b/src/renderer/modules/Macros/MacroCreator.js
@@ -640,7 +640,7 @@ class MacroCreator extends Component {
           <div className="tabWrapper">
             <div className="tabCategories">
               <Title headingLevel={3} text={i18n.general.actions} />
-              <RecordMacroModal onAddRecorded={this.onAddRecorded} />
+              <RecordMacroModal onAddRecorded={this.onAddRecorded} keymapDB={this.keymapDB} />
               <Nav className="flex-column">
                 <CustomTab eventKey="tabText" text="Text" icon={<IconLetterColor />} />
                 <CustomTab eventKey="tabKeys" text="Keys" icon={<IconKeyboard />} />

--- a/src/renderer/modules/Macros/RecordMacroModal.js
+++ b/src/renderer/modules/Macros/RecordMacroModal.js
@@ -177,52 +177,58 @@ export default class RecordMacroModal extends React.Component {
 
   componentDidMount() {
     ipcRenderer.on("recorded-key-down", (event, response) => {
+      const { keymapDB } = this.props;
       const { isDelayActive, recorded } = this.state;
       console.log("Check key-down", response);
       const newRecorded = recorded;
+      const translated = keymapDB.parse(this.translator[response.event.keycode]);
+      console.log("key press", translated);
       if (isDelayActive && recorded.length > 0) {
         const timePast = response.time - recorded[recorded.length - 1].time;
         if (timePast !== undefined && timePast > 1)
           newRecorded.push({
-            char: response.name,
+            char: "delay",
             keycode: timePast,
             action: 2,
             time: response.time,
-            isMod: this.translator[response.event.keycode] >= 224 && this.translator[response.event.keycode] <= 231,
+            isMod: translated.keyCode >= 224 && translated.keyCode <= 231,
           });
       }
       newRecorded.push({
-        char: response.name,
-        keycode: this.translator[response.event.keycode],
+        char: translated.label,
+        keycode: translated.keyCode,
         action: 6,
         time: response.time,
-        isMod: this.translator[response.event.keycode] >= 224 && this.translator[response.event.keycode] <= 231,
+        isMod: translated.keyCode >= 224 && translated.keyCode <= 231,
       });
       this.setState({
         recorded: newRecorded,
       });
     });
     ipcRenderer.on("recorded-key-up", (event, response) => {
+      const { keymapDB } = this.props;
       const { isDelayActive, recorded } = this.state;
       console.log("Check key-up", response);
       const newRecorded = recorded;
+      const translated = keymapDB.parse(this.translator[response.event.keycode]);
+      console.log("key release", translated);
       if (isDelayActive) {
         const timePast = response.time - recorded[recorded.length - 1].time;
         if (timePast !== undefined && timePast > 1)
           newRecorded.push({
-            char: response.name,
+            char: "delay",
             keycode: timePast,
             action: 2,
             time: response.time,
-            isMod: this.translator[response.event.keycode] >= 224 && this.translator[response.event.keycode] <= 231,
+            isMod: translated.keyCode >= 224 && translated.keyCode <= 231,
           });
       }
       newRecorded.push({
-        char: response.name,
-        keycode: this.translator[response.event.keycode],
+        char: translated.label,
+        keycode: translated.keyCode,
         action: 7,
         time: response.time,
-        isMod: this.translator[response.event.keycode] >= 224 && this.translator[response.event.keycode] <= 231,
+        isMod: translated.keyCode >= 224 && translated.keyCode <= 231,
       });
       this.setState({
         recorded: newRecorded,


### PR DESCRIPTION
if you used the macro recorder using a non-standard layout the resulting keypresses were always coded as if you were using an ANSI-US layout, it takes into account the Bazecor configured language to save the input as the expected key for the selected language.