### PR TITLE
fix: single view keyboard now shows correct description for battery keyCode

### DIFF
--- a/src/renderer/modules/KeyPickerKeyboard/KeyPickerKeyboard.js
+++ b/src/renderer/modules/KeyPickerKeyboard/KeyPickerKeyboard.js
@@ -94,12 +94,12 @@ width: -webkit-fill-available;
 .ball-container {
   padding: 8px;
   width: 100%;
-  
+
 }
 .ball-inner {
   display: flex;
   padding: 8px;
-  overflow-y: auto; 
+  overflow-y: auto;
   border: 1px solid ${({ theme }) => theme.styles.standardView.superkeys.key.border};
   border-radius: 3px;
   background-color: ${({ theme }) => theme.styles.standardView.superkeys.key.background};
@@ -225,7 +225,7 @@ width: -webkit-fill-available;
   padding-right: 18px;
 }
 .superkeyTitle h5.actionTitle {
-  font-size: 8px; 
+  font-size: 8px;
   text-transform: uppercase;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -378,7 +378,7 @@ class KeyPickerKeyboard extends Component {
   };
 
   parseKey(keycode) {
-    if (keycode >= 53980 && keycode <= 53980 + 128) {
+    if (keycode >= 53980 && keycode < 54108) {
       let superk = "";
       console.log(this.props.superkeys[keycode - 53980]);
       superk = `SUPER\n${
@@ -386,7 +386,7 @@ class KeyPickerKeyboard extends Component {
       }`;
       return superk;
     }
-    if (keycode > 53851 && keycode <= 53851 + 128) {
+    if (keycode > 53851 && keycode < 53979) {
       let macroN = "";
       console.log(this.props.macros[keycode - 53852]);
       macroN = `MACRO\n${this.props.macros[keycode - 53852] ? this.props.macros[keycode - 53852].name : keycode - 53852}`;

--- a/src/renderer/views/LayoutEditor.js
+++ b/src/renderer/views/LayoutEditor.js
@@ -1919,7 +1919,7 @@ class LayoutEditor extends React.Component {
       if (
         code.modified + code.base > 53980 &&
         code.modified + code.base < 54108 &&
-        superkeys[code.base + code.modified - 53980] != undefined
+        superkeys[code.base + code.modified - 53980] !== undefined
       ) {
         actions = superkeys[code.base + code.modified - 53980].actions;
         superName = superkeys[code.base + code.modified - 53980].name;


### PR DESCRIPTION
These changes fix the Battery button keyCode representation on the single-view keyboard for all of the layouts that have access to it.