### PR TITLE
fix: solved conflict between icons of keypicker keyboard and UI

### DIFF
--- a/src/api/hardware-dygma-raise-iso/components/Keymap-ISO.js
+++ b/src/api/hardware-dygma-raise-iso/components/Keymap-ISO.js
@@ -240,6 +240,7 @@ class KeymapISO extends React.Component {
      * @param {boolean} smallKey if the word longer than key switch to true
      */
     const getDivideKeys = (str, xCord, yCord, smallKey = false) => {
+      if (React.isValidElement(str)) return str;
       const numbers =
         (str.charCodeAt() >= 48 && str.charCodeAt() <= 57) ||
         (str.charCodeAt() >= 96 && str.charCodeAt() <= 105) ||
@@ -304,21 +305,21 @@ class KeymapISO extends React.Component {
           ? getLabel(row, col).extraLabel && getDivideKeys(getLabel(row, col).extraLabel, xCord, yCord, smallKey)
           : getLabel(row, col).extraLabel && getDivideKeys(getLabel(row, col).extraLabel, xCord, String(+yCord - 5), smallKey)
         : getLabel(row, col).extraLabel === getLabel(row, col).extraLabel.toLowerCase().endsWith("to")
-          ? getLabel(row, col).extraLabel && getDivideKeys(getLabel(row, col).extraLabel, xCord, yCord, smallKey)
-          : getLabel(row, col).extraLabel;
+        ? getLabel(row, col).extraLabel && getDivideKeys(getLabel(row, col).extraLabel, xCord, yCord, smallKey)
+        : getLabel(row, col).extraLabel;
 
     const getCenterPrimary = (row, col, xCord, yCord, smallKey = false) =>
       getLabel(row, col).extraLabel !== ""
         ? topsArr.includes(getLabel(row, col).extraLabel)
           ? getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, xCord, yCord, smallKey)
           : topsArrTransfer.includes(getLabel(row, col).extraLabel)
-            ? getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, String(+xCord + 10), yCord, smallKey)
-            : getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, xCord, String(yCord + 2), smallKey)
+          ? getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, String(+xCord + 10), yCord, smallKey)
+          : getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, xCord, String(yCord + 2), smallKey)
         : topsArrTransfer.includes(getLabel(row, col).extraLabel)
-          ? getLabel(row, col).label &&
-            getDivideKeys(getLabel(row, col).label, xCord, yCord, smallKey) &&
-            getDivideKeys(getLabel(row, col).label, String(+xCord + 10), yCord, smallKey)
-          : getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, xCord, String(yCord + 2), smallKey);
+        ? getLabel(row, col).label &&
+          getDivideKeys(getLabel(row, col).label, xCord, yCord, smallKey) &&
+          getDivideKeys(getLabel(row, col).label, String(+xCord + 10), yCord, smallKey)
+        : getLabel(row, col).label && getDivideKeys(getLabel(row, col).label, xCord, String(yCord + 2), smallKey);
 
     return (
       <svg

--- a/src/api/keymap/db/ledeffects.js
+++ b/src/api/keymap/db/ledeffects.js
@@ -15,29 +15,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
+import { IconLEDNextEffectSm, IconLEDPreviousEffectSm, IconLEDToggleEffectSm } from "@Renderer/component/Icon";
+
 const LEDEffectsTable = {
   groupName: "LED Effect",
   keys: [
     {
       code: 17152,
       labels: {
-        primary: "NEXT",
         top: "LED",
+        primary: <IconLEDNextEffectSm />,
+        verbose: "Next",
       },
     },
     {
       code: 17153,
       labels: {
-        primary: "PREV",
         top: "LED",
+        primary: <IconLEDPreviousEffectSm />,
         verbose: "Previous",
       },
     },
     {
       code: 17154,
       labels: {
-        primary: "TOGGLE",
+        primary: <IconLEDToggleEffectSm />,
         top: "LED",
+        verbose: "Toggle",
       },
     },
   ],

--- a/src/api/keymap/db/mediacontrols.js
+++ b/src/api/keymap/db/mediacontrols.js
@@ -15,6 +15,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {
+  IconToolsEjectSm,
+  IconMediaSoundLessSm,
+  IconMediaSoundMoreSm,
+  IconMediaPlayPauseSm,
+  IconMediaStopSm,
+  IconMediaForwardSm,
+  IconMediaSoundMuteSm,
+  IconMediaRewindSm,
+  IconToolsCameraSm,
+  IconToolsCalculatorSm,
+  IconToolsBrightnessMoreSm,
+  IconToolsBrightnessLessSm,
+  IconMediaShuffleSm,
+} from "@Renderer/component/Icon";
+import React from "react";
+
 const MediaControlTable = {
   groupName: "Media",
   keys: [
@@ -22,15 +39,15 @@ const MediaControlTable = {
       code: 19682,
       labels: {
         top: "",
-        primary: "🔇",
-        verbose: "MUTE",
+        primary: <IconMediaSoundMuteSm />,
+        verbose: "Mute",
       },
     },
     {
       code: 22709,
       labels: {
         top: "",
-        primary: "⏭",
+        primary: <IconMediaForwardSm />,
         verbose: "Next track",
       },
     },
@@ -38,7 +55,7 @@ const MediaControlTable = {
       code: 22710,
       labels: {
         top: "",
-        primary: "⏮",
+        primary: <IconMediaRewindSm />,
         verbose: "Prev. track",
       },
     },
@@ -46,15 +63,15 @@ const MediaControlTable = {
       code: 22711,
       labels: {
         top: "",
-        primary: "⏹",
-        verbose: "STOP",
+        primary: <IconMediaStopSm />,
+        verbose: "Stop",
       },
     },
     {
       code: 22733,
       labels: {
         top: "",
-        primary: "⏯",
+        primary: <IconMediaPlayPauseSm />,
         verbose: "Play / pause",
       },
     },
@@ -62,7 +79,7 @@ const MediaControlTable = {
       code: 23785,
       labels: {
         top: "",
-        primary: "🔊",
+        primary: <IconMediaSoundMoreSm />,
         verbose: "Volume up",
       },
     },
@@ -70,7 +87,7 @@ const MediaControlTable = {
       code: 23786,
       labels: {
         top: "",
-        primary: "🔉",
+        primary: <IconMediaSoundLessSm />,
         verbose: "Volume down",
       },
     },
@@ -78,7 +95,7 @@ const MediaControlTable = {
       code: 22712,
       labels: {
         top: "",
-        primary: "⏏",
+        primary: <IconToolsEjectSm />,
         verbose: "Eject",
       },
     },
@@ -86,35 +103,40 @@ const MediaControlTable = {
       code: 18552,
       labels: {
         top: "",
-        primary: "Camera",
+        primary: <IconToolsCameraSm />,
+        verbose: "Camera",
       },
     },
     {
       code: 23663,
       labels: {
         top: "Display",
-        primary: "Bright +",
+        primary: <IconToolsBrightnessMoreSm />,
+        verbose: "Bright +",
       },
     },
     {
       code: 23664,
       labels: {
         top: "Display",
-        primary: "Bright -",
+        primary: <IconToolsBrightnessLessSm />,
+        verbose: "Bright -",
       },
     },
     {
       code: 18834,
       labels: {
-        top: "Apps",
-        primary: "Calc",
+        top: "",
+        primary: <IconToolsCalculatorSm />,
+        verbose: "Calc",
       },
     },
     {
       code: 22713,
       labels: {
-        top: "",
-        primary: "Shuff.",
+        top: "Shuf.",
+        primary: <IconMediaShuffleSm />,
+        verbose: "Shuffle",
       },
     },
   ],

--- a/src/api/keymap/db/miscellaneous.js
+++ b/src/api/keymap/db/miscellaneous.js
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
+
+import { IconShutdownSm, IconSleepSm } from "@Renderer/component/Icon";
 import { withModifiers } from "./utils";
 
 const MiscellaneousTable = {
@@ -43,14 +46,14 @@ const MiscellaneousTable = {
     {
       code: 20865,
       labels: {
-        primary: "SHUT DWN",
+        primary: <IconShutdownSm />,
         verbose: "Shut Down",
       },
     },
     {
       code: 20866,
       labels: {
-        primary: "SLEEP",
+        primary: <IconSleepSm />,
         verbose: "Sleep",
       },
     },

--- a/src/renderer/component/Icon/IconLEDToggleEffect.js
+++ b/src/renderer/component/Icon/IconLEDToggleEffect.js
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+function IconLEDToggleEffectSm(props) {
+  return (
+    <svg width={24} height={24} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M 17.25 5.25 L 6.75 5.25 C 3.027344 5.25 0 8.277344 0 12 C 0 15.722656 3.027344 18.75 6.75 18.75 L 17.25 18.75 C 20.972656 18.75 24 15.722656 24 12 C 24 8.277344 20.972656 5.25 17.25 5.25 Z M 17.25 17.25 C 14.351562 17.25 12 14.898438 12 12 C 12 9.101562 14.351562 6.75 17.25 6.75 C 20.148438 6.75 22.5 9.101562 22.5 12 C 22.496094 14.898438 20.148438 17.246094 17.25 17.25 Z M 17.25 17.25"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export default IconLEDToggleEffectSm;

--- a/src/renderer/component/Icon/IconLEDToggleEffectSm.js
+++ b/src/renderer/component/Icon/IconLEDToggleEffectSm.js
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+function IconLEDToggleEffectSm(props) {
+  return (
+    <svg width={20} height={20} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M 14.375 4.375 L 5.625 4.375 C 2.523438 4.375 0 6.898438 0 10 C 0 13.101562 2.523438 15.625 5.625 15.625 L 14.375 15.625 C 17.476562 15.625 20 13.101562 20 10 C 20 6.898438 17.476562 4.375 14.375 4.375 Z M 14.375 14.375 C 11.957031 14.375 10 12.417969 10 10 C 10 7.582031 11.957031 5.625 14.375 5.625 C 16.792969 5.625 18.75 7.582031 18.75 10 C 18.746094 12.414062 16.789062 14.371094 14.375 14.375 Z M 14.375 14.375"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export default IconLEDToggleEffectSm;

--- a/src/renderer/component/Icon/index.js
+++ b/src/renderer/component/Icon/index.js
@@ -63,6 +63,7 @@ import IconLEDNextEffectSm from "./IconLEDNextEffectSm";
 import IconLEDPreviousEffect from "./IconLEDPreviousEffect";
 import IconLEDPreviousEffectSm from "./IconLEDPreviousEffectSm";
 import IconLEDSwitchLeft from "./IconLEDSwitchLeft";
+import IconLEDToggleEffectSm from "./IconLEDToggleEffectSm";
 import IconLetterColor from "./IconLetterColor";
 import IconLoader from "./IconLoader";
 import IconMemory2Stroke from "./IconMemory2Stroke";
@@ -202,6 +203,7 @@ export {
   IconLEDNextEffectSm,
   IconLEDPreviousEffect,
   IconLEDPreviousEffectSm,
+  IconLEDToggleEffectSm,
   IconLetterColor,
   IconLoader,
   IconMediaForward,

--- a/src/renderer/modules/KeyPickerKeyboard/KeyPicker.js
+++ b/src/renderer/modules/KeyPickerKeyboard/KeyPicker.js
@@ -78,6 +78,7 @@ import {
   IconRobotSm,
   IconWrenchSm,
   IconWirelessSm,
+  IconLEDToggleEffectSm,
 } from "@Renderer/component/Icon";
 
 import i18n from "@Renderer/i18n";
@@ -499,13 +500,13 @@ class KeyPicker extends Component {
             code === null
               ? false
               : Array.isArray(key.idArray)
-                ? key.idArray.some(key => key === code.base + code.modified || (key === code.base && key >= 104 && key <= 115))
-                : code.base === key.id &&
-                    (code.base + code.modified < 53267 || code.base + code.modified > 60000) &&
-                    (code.base + code.modified < 17450 || code.base + code.modified > 17501) &&
-                    (code.base + code.modified < 49153 || code.base + code.modified > 49168)
-                  ? true
-                  : !!(code.modified > 0 && code.base + code.modified === key.id)
+              ? key.idArray.some(key => key === code.base + code.modified || (key === code.base && key >= 104 && key <= 115))
+              : code.base === key.id &&
+                (code.base + code.modified < 53267 || code.base + code.modified > 60000) &&
+                (code.base + code.modified < 17450 || code.base + code.modified > 17501) &&
+                (code.base + code.modified < 49153 || code.base + code.modified > 49168)
+              ? true
+              : !!(code.modified > 0 && code.base + code.modified === key.id)
           }
           clicked={() => {
             key.mod === disableMods || key.move === disableMove ? () => {} : this.onKeyPress(key.id);
@@ -827,7 +828,7 @@ class KeyPicker extends Component {
               </div>
               <div className="keysButtonsList">
                 <ButtonConfig
-                  buttonText={i18n.editor.superkeys.specialKeys.ledToggleText}
+                  icoSVG={<IconLEDToggleEffectSm />}
                   tooltip={i18n.editor.superkeys.specialKeys.ledToggleTootip}
                   tooltipDelay={300}
                   onClick={() => {

--- a/src/renderer/modules/KeyPickerKeyboard/KeyPickerKeyboard.js
+++ b/src/renderer/modules/KeyPickerKeyboard/KeyPickerKeyboard.js
@@ -392,6 +392,7 @@ class KeyPickerKeyboard extends Component {
       macroN = `MACRO\n${this.props.macros[keycode - 53852] ? this.props.macros[keycode - 53852].name : keycode - 53852}`;
       return macroN;
     }
+    if (React.isValidElement(this.keymapDB.parse(keycode).label)) return this.keymapDB.parse(keycode).label;
     return this.props.code !== null
       ? this.keymapDB.parse(keycode).extraLabel != undefined
         ? `${this.keymapDB.parse(keycode).extraLabel}.${this.keymapDB.parse(keycode).label}`

--- a/src/renderer/modules/KeyVisualizer/KeyVisualizer.js
+++ b/src/renderer/modules/KeyVisualizer/KeyVisualizer.js
@@ -173,7 +173,7 @@ class KeyVisualizer extends React.Component {
 
     return (
       <Style className="KeyVisualizer">
-        <div className={`KeyVisualizerInner ${newValue != oldValue && isStandardView ? "showConnection" : ""}`}>
+        <div className={`KeyVisualizerInner ${newValue !== oldValue && isStandardView ? "showConnection" : ""}`}>
           {oldValue ? (
             <div className="oldKeyValue">
               <Title text={`${rows ? rows[superkeyAction].title : "Selected value"}`} headingLevel={4} />
@@ -199,7 +199,7 @@ class KeyVisualizer extends React.Component {
           ) : (
             ""
           )}
-          {newValue != oldValue && isStandardView ? (
+          {newValue !== oldValue && isStandardView ? (
             <div className="newKeyValue">
               <Title text="New value" headingLevel={4} />
               <div className="keySelectedBox">

--- a/src/renderer/modules/KeysTabs/MediaAndLightTab.js
+++ b/src/renderer/modules/KeysTabs/MediaAndLightTab.js
@@ -22,6 +22,7 @@ import {
   IconToolsEjectSm,
   IconLEDPreviousEffectSm,
   IconLEDNextEffectSm,
+  IconLEDToggleEffectSm,
   IconSleepSm,
   IconShutdownSm,
 } from "@Renderer/component/Icon";
@@ -177,7 +178,7 @@ class MediaAndLightTab extends Component {
               <p className="description">{i18n.editor.superkeys.specialKeys.LEDDescription}</p>
               <div className="keysButtonsList">
                 <ButtonConfig
-                  buttonText={i18n.editor.superkeys.specialKeys.ledToggleText}
+                  icoSVG={<IconLEDToggleEffectSm />}
                   tooltip={i18n.editor.superkeys.specialKeys.ledToggleTootip}
                   tooltipDelay={300}
                   className="buttonConfigLED"

--- a/src/renderer/modules/StandardView/StandardView.js
+++ b/src/renderer/modules/StandardView/StandardView.js
@@ -262,6 +262,7 @@ export default class StandardView extends React.Component {
     if (keycode >= 53852 && keycode <= 53852 + 128) {
       if (this.props.code !== null) return `${this.keymapDB.parse(keycode).extraLabel}.${macroName}`;
     }
+    if (React.isValidElement(this.keymapDB.parse(keycode).label)) return this.keymapDB.parse(keycode).label;
     return this.props.code !== null
       ? this.keymapDB.parse(keycode).extraLabel != undefined
         ? `${this.keymapDB.parse(keycode).extraLabel}.${this.keymapDB.parse(keycode).label}`


### PR DESCRIPTION
This fix solves icon inconsistencies between different layouts, like single and standard view key preview, UI representation of the keyboard, and the key picker keyboard that had a different (and newer) set of icons