### PR TITLE
Use uaccess tag instead of mode 666 in udev rules and split Defy rules

### DIFF
--- a/src/main/utils/udev.ts
+++ b/src/main/utils/udev.ts
@@ -4,10 +4,20 @@ import * as sudo from "sudo-prompt";
 import log from "electron-log/main";
 
 const udevRulesToWrite =`\
+# Dygma Raise
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", MODE="0660", TAG+="uaccess"
+# bootloader mode
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2201", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", MODE="0666", TAG+="uaccess"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="35ef", MODE="0660", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="35ef", MODE="0660", TAG+="uaccess"
+
+# Dygma Defy
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="35ef", ATTRS{idProduct}=="0010", MODE="0660", TAG+="uaccess"
+# bootloader mode
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="35ef", ATTRS{idProduct}=="0011", MODE="0660", TAG+="uaccess"
+
+# Dygma Defy wireless
+KERNEL=="hidraw*", ATTRS{idVendor}=="35ef", ATTRS{idProduct}=="0010", MODE="0660", TAG+="uaccess"
+# bootloader mode
+KERNEL=="hidraw*", ATTRS{idVendor}=="35ef", ATTRS{idProduct}=="0011", MODE="0660", TAG+="uaccess"
 `;
 
 const filename = "/etc/udev/rules.d/60-dygma.rules";

--- a/src/main/utils/udev.ts
+++ b/src/main/utils/udev.ts
@@ -3,10 +3,14 @@ import fs from "fs";
 import * as sudo from "sudo-prompt";
 import log from "electron-log/main";
 
-const udevRulesToWrite =
-  'SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2201", MODE="0666"\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", MODE="0666"\nSUBSYSTEMS=="usb", ATTRS{idVendor}=="35ef", MODE="0666"\nKERNEL=="hidraw*", ATTRS{idVendor}=="35ef", MODE="0666"';
+const udevRulesToWrite =`\
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2201", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2200", MODE="0666", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="35ef", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="35ef", MODE="0660", TAG+="uaccess"
+`;
 
-const filename = "/etc/udev/rules.d/10-dygma.rules";
+const filename = "/etc/udev/rules.d/60-dygma.rules";
 
 const checkUdev = () => {
   try {


### PR DESCRIPTION
This is according to #684 . IMHO, it's not ideal, because this way still any process of currently logged-in user will have access to keyboard's interfaces, but at least processes run by other users won't.

These rules should be a drop-in replacement for current rules and they worked fine on my computer, but I think it would be very good if someone else tried these on their computer first.

AFAIR, udev tags are being set up in a way that requires Dygma rules to be run at a later stage, thus `60-dygma.rules` in this PR. If merged, this will require Dygma users to relete `10-dygma.rules` unless some code to clean it up is added (IMHO, cleanup code is not worth the effort).

I'm not sure about:
* device vs device in bootloader mode product ids
* USB vs wireless comments