### PR TITLE
[fix] Color palette sometimes not showing colors assigned to slots.

### DIFF
--- a/src/renderer/modules/ColorEditor/ColorEditor.tsx
+++ b/src/renderer/modules/ColorEditor/ColorEditor.tsx
@@ -123,13 +123,13 @@ class ColorEditor extends Component<ColorEditorProps, { displayColorPicker: bool
   }
 
   render() {
-    const { colors, selected, toChangeAllKeysColor, deviceName, colorsInUse } = this.props;
+    const { colors, selected, toChangeAllKeysColor, deviceName } = this.props;
     const { displayColorPicker } = this.state;
 
     const layerButtons = colors.map((data, idx) => {
       const menuKey = `color-${idx.toString()}-${colors[idx].rgb.toString()}`;
       const buttonStyle = {
-        backgroundColor: colorsInUse[idx] ? colors[idx].rgb : "transparent",
+        backgroundColor: colors[idx].rgb,
       };
       return (
         // eslint-disable-next-line react/jsx-filename-extension

--- a/src/renderer/types/colorEditor.ts
+++ b/src/renderer/types/colorEditor.ts
@@ -23,7 +23,6 @@ export interface ColorEditorProps {
   onColorSelect: (colorIndex: number) => void;
   colorButtonIsSelected: boolean;
   onColorPick: (colorIndex: number, r: number, g: number, b: number) => void;
-  colorsInUse: boolean[];
   selected: number;
   isColorButtonSelected: boolean;
   onColorButtonSelect: (action: string, colorIndex: number) => void;

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -1837,11 +1837,6 @@ const LayoutEditor = (props: LayoutEditorProps) => {
               onColorSelect={onColorSelect}
               colorButtonIsSelected={isColorButtonSelected}
               onColorPick={onColorPick}
-              colorsInUse={palette.map((color, idx) => {
-                const presence = colorMap.map(lx => lx.find((x: number) => x === idx));
-                if (presence.find(x => x !== undefined) !== undefined) return true;
-                return false;
-              })}
               selected={selectedPaletteColor}
               isColorButtonSelected={isColorButtonSelected}
               onColorButtonSelect={onColorButtonSelect}


### PR DESCRIPTION
When a color was assigned to color palette slot, but that slot was not used in any backlight led, underglow led or neuron then this color would not be displayed on color palette. Problem discussed [here](https://discordapp.com/channels/895297925578637362/1199911011877130423).