### PR TITLE
fix: added web preference that prevents background throttling of JS code

### DIFF
--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -41,6 +41,7 @@ const createWindow = () => {
       nodeIntegration: true,
       contextIsolation: false,
       webSecurity: false,
+      backgroundThrottling: false,
     },
   });
 


### PR DESCRIPTION
Bazecor stopped flashing the neuron and sides during the firmware update process due to the main window losing focus, this was due to a chromium feature in which any background JS activity was throttled and the renderization was blocked when the window was in the background or minimized.