### PR TITLE
fix: missing settings property "isStandardView" prevents app from start

### DIFF
--- a/src/main/managers/Store.ts
+++ b/src/main/managers/Store.ts
@@ -23,7 +23,7 @@ const schema: Schema<StorageType> = {
       showDefaults: false,
       isStandardView: true,
     },
-    required: ["backupFolder", "backupFrequency", "language", "darkMode", "showDefaults", "isStandardView"],
+    required: ["backupFolder", "backupFrequency", "language", "darkMode", "showDefaults"],
   },
   neurons: {
     type: "array",

--- a/src/renderer/utils/Store.ts
+++ b/src/renderer/utils/Store.ts
@@ -24,7 +24,7 @@ const schema: Schema<StorageType> = {
       showDefaults: false,
       isStandardView: true,
     },
-    required: ["backupFolder", "backupFrequency", "language", "darkMode", "showDefaults", "isStandardView"],
+    required: ["backupFolder", "backupFrequency", "language", "darkMode", "showDefaults"],
   },
   neurons: {
     type: "array",


### PR DESCRIPTION
This one was not addressed in previous commits. 
~I also suspect wrong default value for "language" property. Shouldn't it be "en-US"?~