### PR TITLE
fix: firstChild was comming out as undefined in some instances

### DIFF
--- a/src/renderer/modules/Macros/TimelineEditorForm.js
+++ b/src/renderer/modules/Macros/TimelineEditorForm.js
@@ -90,16 +90,18 @@ class MacroForm extends Component {
 
   wheelPosStart = () => {
     const { updateScroll } = this.props;
-    const scrollContainer = document.getElementById("hwTracker").firstChild;
-    scrollContainer.scrollLeft = 0;
-    updateScroll(0);
+    const scrollContainer = document.getElementById("hwTracker")?.firstChild;
+    if (scrollContainer?.scrollLeft !== undefined) {
+      scrollContainer.scrollLeft = 0;
+      updateScroll(0);
+    }
   };
 
   wheelPosEnd = () => {
     const { updateScroll } = this.props;
-    const scrollContainer = document.getElementById("hwTracker").firstChild;
+    const scrollContainer = document.getElementById("hwTracker")?.firstChild;
     // console.log("checking end pos of scroll", scrollContainer, scrollContainer.scrollWidth);
-    updateScroll(scrollContainer.scrollWidth);
+    if (scrollContainer?.scrollWidth !== undefined) updateScroll(scrollContainer.scrollWidth);
   };
 
   render() {

--- a/src/renderer/modules/Macros/TimelineEditorMacroTable.js
+++ b/src/renderer/modules/Macros/TimelineEditorMacroTable.js
@@ -208,7 +208,7 @@ class TimelineEditorMacroTable extends Component {
       });
     }
     if (rows.length !== 0) {
-      const scrollContainer = this.horizontalWheel.current.firstChild;
+      const scrollContainer = this.horizontalWheel.current?.firstChild;
       // console.log("comparing values of scrollpos in mount", this.props.scrollPos, scrollContainer.scrollLeft);
       scrollContainer.addEventListener("wheel", this.scrollUpdate);
     }
@@ -218,7 +218,7 @@ class TimelineEditorMacroTable extends Component {
     const { macro, scrollPos } = this.props;
     const { rows } = this.state;
     if (this.horizontalWheel.current === null) return;
-    const scrollContainer = this.horizontalWheel.current.firstChild;
+    const scrollContainer = this.horizontalWheel.current?.firstChild;
     if (rows.length !== 0 && prevState.rows.length === 0) {
       scrollContainer.addEventListener("wheel", this.scrollUpdate);
     }
@@ -248,7 +248,7 @@ class TimelineEditorMacroTable extends Component {
   componentWillUnmount() {
     const { rows } = this.state;
     if (rows.length !== 0) {
-      const scrollContainer = this.horizontalWheel.current.firstChild;
+      const scrollContainer = this.horizontalWheel.current?.firstChild;
       scrollContainer.removeEventListener("wheel", this.scrollUpdate);
     }
   }
@@ -291,7 +291,7 @@ class TimelineEditorMacroTable extends Component {
 
   scrollUpdate = evt => {
     const { updateScroll } = this.props;
-    const scrollContainer = this.horizontalWheel.current.firstChild;
+    const scrollContainer = this.horizontalWheel.current?.firstChild;
     if (typeof evt.preventDefault === "function") {
       evt.preventDefault();
       scrollContainer.scrollLeft += evt.deltaY;


### PR DESCRIPTION
in some specific cases the firstChild of some timeline macros elements could be not detected, this PR prevents that form happening
![image-ezgif com-webp-to-jpg-converter](https://github.com/Dygmalab/Bazecor/assets/14853921/c63be28e-e646-492f-bfa8-0783f374fdaa)
