### PR TITLE
fix: standardview now resets selected key when changing modes

### DIFF
--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -1576,6 +1576,8 @@ const LayoutEditor = (props: LayoutEditorProps) => {
 
   const onToggleStandardView = () => {
     setIsStandardView(!isStandardView);
+    setCurrentKeyIndex(-1);
+    setCurrentLedIndex(-1);
     setViewMode(!isStandardView ? "standard" : "single");
   };
 


### PR DESCRIPTION
changing mode with a key selected was creating false inputs and representation errors on the single view representation