### PR TITLE
fix: superkeys view now checks for undefined string before .substr

### DIFF
--- a/src/renderer/component/Button/SuperkeyPicker.tsx
+++ b/src/renderer/component/Button/SuperkeyPicker.tsx
@@ -198,8 +198,8 @@ function SuperkeyPicker(props: SuperkeyPickerProps) {
     if (aux.extraLabel === "MACRO") {
       const macroID = superkeys[selected].actions[index] - 53852;
       // console.log("checking macroID", macroID);
-      if (macros.length > macroID && macros[macroID].name.substr(0, 5) !== "") {
-        setKeyContent((aux.label = macros[macroID].name.substr(0, 5).toLowerCase()));
+      if (macros.length > macroID && macros[macroID]?.name?.substr(0, 5) !== "") {
+        setKeyContent((aux.label = macros[macroID]?.name?.substr(0, 5).toLowerCase()));
         return;
       }
       setKeyContent(`${aux.extraLabel} ${aux.label}`);

--- a/src/renderer/modules/KeysTabs/SuperkeysTab.tsx
+++ b/src/renderer/modules/KeysTabs/SuperkeysTab.tsx
@@ -148,8 +148,8 @@ class SuperkeysTab extends Component<SuperkeysTabProps> {
 
     if (aux.extraLabel === "MACRO") {
       const { macros } = this.props;
-      if (macros.length > parseInt(aux.label, 10) && macros[parseInt(aux.label, 10)].name.substr(0, 5) !== "") {
-        translatedAction = aux.label + macros[parseInt(aux.label, 10)].name.substr(0, 5).toLowerCase();
+      if (macros.length > parseInt(aux.label, 10) && macros[parseInt(aux.label, 10)]?.name?.substr(0, 5) !== "") {
+        translatedAction = `${aux.label} ${macros[parseInt(aux.label, 10)]?.name?.substr(0, 5).toLowerCase()}`;
       }
     }
     if (aux.label) {


### PR DESCRIPTION
This issue comes from a Discord reported bug from Blasterra:
When I click on super keys (the button on the right panel to get into the editor) in 1.4.0-rc5 I get this: 

![image](https://github.com/Dygmalab/Bazecor/assets/14853921/8e25a815-7946-44c8-a34e-0caf3da4bfba)
