### PR TITLE
fix: now keys selected on standard view behave as expected in superkView

### DIFF
--- a/src/renderer/modules/StandardView/StandardView.tsx
+++ b/src/renderer/modules/StandardView/StandardView.tsx
@@ -277,6 +277,7 @@ export default class StandardView extends React.Component<StandardViewProps, Sta
   };
 
   onAddSpecial = (keycode: number) => {
+    log.info("added Special!", keycode);
     this.updateSelected(keycode);
   };
 
@@ -345,7 +346,6 @@ export default class StandardView extends React.Component<StandardViewProps, Sta
       isStandardView,
       kbtype,
       keyIndex,
-      layerData,
       macros,
       selectedlanguage,
       showStandardView,
@@ -355,16 +355,16 @@ export default class StandardView extends React.Component<StandardViewProps, Sta
     const { stateCode, selected, currentTab } = this.state;
     let keyCode: number;
     if (actTab === "super") {
-      keyCode = keyIndex !== -1 ? layerData[keyIndex].keyCode : 0;
+      keyCode = selected;
     } else {
       keyCode = selected;
     }
     const selKey = this.parseKey(keyCode);
     const oldKey = this.parseKey(stateCode);
     if (!showStandardView) return null;
-    log.info(
-      `StandardView statecode:${stateCode} selected:${selected} currentTab: ${currentTab} selKey: ${selKey} oldKey: ${oldKey}`,
-    );
+    // log.info(
+    //   `StandardView statecode:${stateCode} selected:${selected} actTab: ${actTab} currentTab: ${currentTab} selKey: ${selKey} oldKey: ${oldKey}`,
+    // );
 
     const tabVariants = {
       hidden: { opacity: 0 },

--- a/src/renderer/views/SuperkeysEditor.tsx
+++ b/src/renderer/views/SuperkeysEditor.tsx
@@ -687,7 +687,7 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
   };
 
   const closeStandardViewModal = (code: number) => {
-    onKeyChange(code);
+    if (code) onKeyChange(code);
     state.showStandardView = false;
     state.selectedAction = -1;
     setState({ ...state });
@@ -830,15 +830,6 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
 
       <ToggleGroupLayoutViewMode value={viewMode} onValueChange={onToggle} view="superkeys" />
 
-      {/* <LayoutViewSelector
-        onToggle={onToggle}
-        isStandardView={isStandardViewSuperkeys}
-        tooltip={i18n.editor.superkeys.tooltip}
-        layoutSelectorPosition={{
-          x: 0,
-          y: 0,
-        }}
-      /> */}
       {isStandardViewSuperkeys ? (
         <StandardView
           showStandardView={showStandardView}


### PR DESCRIPTION
Standard view key selector was acting wierdly in Superkeys view due to the latest modifications applied to it.