### PR TITLE
Fix typo in LED Preferences page

### DIFF
--- a/src/renderer/modules/Settings/LEDSettings.tsx
+++ b/src/renderer/modules/Settings/LEDSettings.tsx
@@ -287,7 +287,6 @@ function LEDSettings(props: LEDSettingsPreferences) {
                 </span>
                 {`It's essential to note that LEDs can significantly impact battery consumption. To optimize battery life when using
                 your device wirelessly, you can finely adjust LED intensity.`}
-                `
               </p>
             </div>
           </>


### PR DESCRIPTION
There is a trailing backtick symbol (`) at the end of Preferences -> LED settings page.
![image](https://github.com/Dygmalab/Bazecor/assets/64351143/fa8140ef-abc8-4c8f-84e9-f8b0b508f84f)
This fixes this small typo.