### PR TITLE
fix: added delay to mitigate wireless battery commands intrusion

### DIFF
--- a/src/renderer/views/Preferences.tsx
+++ b/src/renderer/views/Preferences.tsx
@@ -62,6 +62,7 @@ import { WirelessInterface } from "@Renderer/types/wireless";
 import LogoLoader from "@Renderer/components/atoms/loader/LogoLoader";
 import { Neuron } from "@Renderer/types/neurons";
 import Backup from "../../api/backup";
+import { delay } from "../../api/flash/delay";
 
 const store = Store.getStore();
 
@@ -419,6 +420,7 @@ const Preferences = (props: PreferencesProps) => {
 
   const saveContext = async () => {
     setLoading(true);
+    await delay(250);
 
     try {
       await saveKeymapChanges();


### PR DESCRIPTION
When saving preferences, you can in some cases coincide with a battery petition due to race conditions when saving, which can alter values in the sending buffer and make preferences configuration fail to be delivered.

to prevent this a delay has been included between the disable action of the battery reader and the commands to set the new preferences values