### PR TITLE
feat: Extend ClearLayer

### DIFF
--- a/src/renderer/components/molecules/CustomModal/ClearLayerDialog.tsx
+++ b/src/renderer/components/molecules/CustomModal/ClearLayerDialog.tsx
@@ -10,6 +10,7 @@ import { NOKEY_KEY_CODE, TRANS_KEY_CODE } from "../../../../api/keymap/types";
 export interface OnConfirmProps {
   keyCode: number;
   colorIndex: number;
+  chooseYourKeyboardSide: KeyboardSide;
 }
 
 type KeyboardSide = "BOTH" | "LEFT" | "RIGHT";
@@ -60,7 +61,9 @@ export const ClearLayerDialog = (props: ClearLayerDialogProps): JSX.Element => {
             className="ml-3 mt-2 mb-3"
           />
           <div className="grid items-center w-full justify-between py-2">
-            <div className="mb-4">{createLabel(i18n.editor.modal.clearLayer.entireKeyboard, "chooseYourSideOrFull")}</div>
+            <div className="mb-4">
+              {createLabel(i18n.editor.modal.clearLayer.chooseYourKeyboardSide, "chooseYourKeyboardSide")}
+            </div>
             <ToggleGroup
               triggerFunction={chooseYourKeyboardSideUpdate}
               value={chooseYourKeyboardSide}
@@ -98,6 +101,7 @@ export const ClearLayerDialog = (props: ClearLayerDialogProps): JSX.Element => {
               onConfirm({
                 keyCode: useNoKey ? NOKEY_KEY_CODE : TRANS_KEY_CODE,
                 colorIndex: indexOfSelectedColor < colors.length ? indexOfSelectedColor : -1,
+                chooseYourKeyboardSide,
               })
             }
           >

--- a/src/renderer/components/molecules/CustomModal/ClearLayerDialog.tsx
+++ b/src/renderer/components/molecules/CustomModal/ClearLayerDialog.tsx
@@ -12,6 +12,8 @@ export interface OnConfirmProps {
   colorIndex: number;
 }
 
+type KeyboardSide = "BOTH" | "LEFT" | "RIGHT";
+
 interface ClearLayerDialogProps {
   open: boolean;
   onCancel: () => void;
@@ -19,11 +21,13 @@ interface ClearLayerDialogProps {
   colors?: PaletteType[];
   selectedColorIndex?: number;
   fillWithNoKey?: boolean;
+  keyboardSide?: KeyboardSide;
 }
 
 export const ClearLayerDialog = (props: ClearLayerDialogProps): JSX.Element => {
-  const { open, onCancel, onConfirm, colors, selectedColorIndex, fillWithNoKey } = props;
+  const { open, onCancel, onConfirm, colors, selectedColorIndex, fillWithNoKey, keyboardSide } = props;
   const [useNoKey, setUseNoKey] = useState(fillWithNoKey ?? false);
+  const [chooseYourKeyboardSide, setChooseYourKeyboardSide] = useState(keyboardSide ?? "BOTH");
   const [indexOfSelectedColor, setIndexOfSelectedColor] = useState(selectedColorIndex ?? -1);
   const createLabel = (text: string, forId: string) => (
     <label htmlFor={forId} className="grow m-0 font-semibold">
@@ -33,6 +37,10 @@ export const ClearLayerDialog = (props: ClearLayerDialogProps): JSX.Element => {
 
   const useNoKeyUpdate = (value: boolean) => {
     setUseNoKey(value);
+  };
+
+  const chooseYourKeyboardSideUpdate = (value: KeyboardSide) => {
+    setChooseYourKeyboardSide(value);
   };
 
   return (
@@ -51,6 +59,20 @@ export const ClearLayerDialog = (props: ClearLayerDialogProps): JSX.Element => {
             onColorSelect={idx => setIndexOfSelectedColor(idx)}
             className="ml-3 mt-2 mb-3"
           />
+          <div className="grid items-center w-full justify-between py-2">
+            <div className="mb-4">{createLabel(i18n.editor.modal.clearLayer.entireKeyboard, "chooseYourSideOrFull")}</div>
+            <ToggleGroup
+              triggerFunction={chooseYourKeyboardSideUpdate}
+              value={chooseYourKeyboardSide}
+              listElements={[
+                { value: "BOTH", name: "Full Keyboard", icon: "", index: 0 },
+                { value: "LEFT", name: "Left Side", icon: "", index: 1 },
+                { value: "RIGHT", name: "Right Side", icon: "", index: 2 },
+              ]}
+              variant="flex"
+              size="sm"
+            />
+          </div>
           <div className="grid items-center w-full justify-between py-2">
             <div className="mb-4">{createLabel(i18n.editor.modal.clearLayer.useNoKey, "useNoKeyInstead")}</div>
             <ToggleGroup

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -257,7 +257,7 @@ const English = {
         title: "Clear layer",
         resetColors: "Reset underglow and key colors using the selection",
         useNoKey: "Fill layer with NOKEY instead of TRANS key",
-        entireKeyboard: "Choose the entire keyboard, left or right side",
+        chooseYourKeyboardSide: "Choose the entire keyboard, left or right side",
       },
     },
     standardView: {

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -257,6 +257,7 @@ const English = {
         title: "Clear layer",
         resetColors: "Reset underglow and key colors using the selection",
         useNoKey: "Fill layer with NOKEY instead of TRANS key",
+        entireKeyboard: "Choose the entire keyboard, left or right side",
       },
     },
     standardView: {

--- a/src/renderer/modules/ColorEditor/ColorPalette.tsx
+++ b/src/renderer/modules/ColorEditor/ColorPalette.tsx
@@ -12,6 +12,8 @@ const Container = Styled.div`
       grid-gap: 4px;
     `;
 
+const Style = Styled.div``;
+
 export const ColorPalette = (props: ColorPaletteProps) => {
   const { colors, onColorSelect, selected, className } = props;
 
@@ -19,14 +21,16 @@ export const ColorPalette = (props: ColorPaletteProps) => {
     const menuKey = `color-${idx.toString()}-${data.rgb.toString()}`;
     if (data.rgb === "transparent") {
       return (
-        <button
-          type="button"
+        <Style
+          tabIndex={-1}
           key={`${menuKey}-key-${data}`}
-          onClick={() => onColorSelect(idx)}
-          className="w-[81px] border border-solid !border-[#7b869e] h-8 m-0 p-1 text-gray-300 hover:text-white focus:outline-none focus:!border-[#6c5ce7] focus:shadow-[0_4px_24px_0px_rgba(108,92,231,0.6)]"
+          onClick={() => {
+            onColorSelect(idx);
+          }}
+          className="text-sm cursor-pointer w-[81px] border border-solid !border-[#7b869e] h-8 m-0 p-1 text-gray-300 hover:text-white focus:outline-none focus:!border-[#6c5ce7] focus:shadow-[0_4px_24px_0px_rgba(108,92,231,0.6)] focus:text-white"
         >
           No change
-        </button>
+        </Style>
       );
     }
     const buttonStyle = {

--- a/src/renderer/types/LayerMap.ts
+++ b/src/renderer/types/LayerMap.ts
@@ -1,0 +1,38 @@
+export type LayerMap = {
+  keys: {
+    position: {
+      right: [
+        {
+          from: number;
+          to: number;
+        },
+      ];
+      left: [
+        {
+          from: number;
+          to: number;
+        },
+      ];
+    };
+    leds: {
+      right: {
+        from: number;
+        to: number;
+      };
+      left: {
+        from: number;
+        to: number;
+      };
+    };
+  };
+  underglow: {
+    right: {
+      from: number;
+      to: number;
+    };
+    left: {
+      from: number;
+      to: number;
+    };
+  };
+};

--- a/src/renderer/types/LayerMap.ts
+++ b/src/renderer/types/LayerMap.ts
@@ -1,38 +1,21 @@
+type Period = {
+  from: number;
+  to: number;
+};
+
 export type LayerMap = {
   keys: {
     position: {
-      right: [
-        {
-          from: number;
-          to: number;
-        },
-      ];
-      left: [
-        {
-          from: number;
-          to: number;
-        },
-      ];
+      right: Period[];
+      left: Period[];
     };
     leds: {
-      right: {
-        from: number;
-        to: number;
-      };
-      left: {
-        from: number;
-        to: number;
-      };
+      right: Period;
+      left: Period;
     };
   };
   underglow: {
-    right: {
-      from: number;
-      to: number;
-    };
-    left: {
-      from: number;
-      to: number;
-    };
+    right: Period;
+    left: Period;
   };
 };

--- a/src/renderer/utils/LayersMap.ts
+++ b/src/renderer/utils/LayersMap.ts
@@ -74,28 +74,70 @@ const defyLayerMap: LayerMap = {
 const raiseLayerMap: LayerMap = {
   keys: {
     position: {
-      left: [],
-      right: [],
+      left: [
+        {
+          from: 0,
+          to: 7,
+        },
+        {
+          from: 16,
+          to: 23,
+        },
+        {
+          from: 32,
+          to: 39,
+        },
+        {
+          from: 48,
+          to: 55,
+        },
+        {
+          from: 64,
+          to: 72,
+        },
+      ],
+      right: [
+        {
+          from: 9,
+          to: 16,
+        },
+        {
+          from: 24,
+          to: 32,
+        },
+        {
+          from: 41,
+          to: 48,
+        },
+        {
+          from: 57,
+          to: 64,
+        },
+        {
+          from: 72,
+          to: 80,
+        },
+      ],
     },
     leds: {
       left: {
         from: 0,
-        to: 0,
+        to: 33,
       },
       right: {
-        from: 0,
-        to: 0,
+        from: 33,
+        to: 69,
       },
     },
   },
   underglow: {
     left: {
-      from: 0,
-      to: 0,
+      from: 69,
+      to: 99,
     },
     right: {
-      from: 0,
-      to: 0,
+      from: 99,
+      to: 131,
     },
   },
 };
@@ -103,28 +145,70 @@ const raiseLayerMap: LayerMap = {
 const raise2LayerMap: LayerMap = {
   keys: {
     position: {
-      left: [],
-      right: [],
+      left: [
+        {
+          from: 0,
+          to: 7,
+        },
+        {
+          from: 16,
+          to: 23,
+        },
+        {
+          from: 32,
+          to: 39,
+        },
+        {
+          from: 48,
+          to: 55,
+        },
+        {
+          from: 64,
+          to: 72,
+        },
+      ],
+      right: [
+        {
+          from: 9,
+          to: 16,
+        },
+        {
+          from: 24,
+          to: 32,
+        },
+        {
+          from: 41,
+          to: 48,
+        },
+        {
+          from: 57,
+          to: 64,
+        },
+        {
+          from: 72,
+          to: 80,
+        },
+      ],
     },
     leds: {
       left: {
         from: 0,
-        to: 0,
+        to: 33,
       },
       right: {
-        from: 0,
-        to: 0,
+        from: 33,
+        to: 69,
       },
     },
   },
   underglow: {
     left: {
-      from: 0,
-      to: 0,
+      from: 69,
+      to: 105,
     },
     right: {
-      from: 0,
-      to: 0,
+      from: 105,
+      to: 144,
     },
   },
 };

--- a/src/renderer/utils/LayersMap.ts
+++ b/src/renderer/utils/LayersMap.ts
@@ -6,67 +6,67 @@ const defyLayerMap: LayerMap = {
       left: [
         {
           from: 0,
-          to: 6,
+          to: 7,
         },
         {
           from: 16,
-          to: 22,
+          to: 23,
         },
         {
           from: 32,
-          to: 38,
+          to: 39,
         },
         {
           from: 48,
-          to: 53,
+          to: 54,
         },
         {
           from: 64,
-          to: 71,
+          to: 72,
         },
       ],
       right: [
         {
           from: 9,
-          to: 15,
+          to: 16,
         },
         {
           from: 25,
-          to: 31,
+          to: 32,
         },
         {
           from: 41,
-          to: 47,
+          to: 48,
         },
         {
           from: 57,
-          to: 63,
+          to: 64,
         },
         {
           from: 72,
-          to: 79,
+          to: 80,
         },
       ],
     },
     leds: {
       left: {
         from: 0,
-        to: 34,
+        to: 35,
       },
       right: {
         from: 35,
-        to: 69,
+        to: 70,
       },
     },
   },
   underglow: {
     left: {
       from: 70,
-      to: 122,
+      to: 123,
     },
     right: {
       from: 123,
-      to: 175,
+      to: 176,
     },
   },
 };

--- a/src/renderer/utils/LayersMap.ts
+++ b/src/renderer/utils/LayersMap.ts
@@ -1,0 +1,145 @@
+import { LayerMap } from "@Types/LayerMap";
+
+const defyLayerMap: LayerMap = {
+  keys: {
+    position: {
+      left: [
+        {
+          from: 0,
+          to: 6,
+        },
+        {
+          from: 16,
+          to: 22,
+        },
+        {
+          from: 32,
+          to: 38,
+        },
+        {
+          from: 48,
+          to: 53,
+        },
+        {
+          from: 64,
+          to: 71,
+        },
+      ],
+      right: [
+        {
+          from: 9,
+          to: 15,
+        },
+        {
+          from: 25,
+          to: 31,
+        },
+        {
+          from: 41,
+          to: 47,
+        },
+        {
+          from: 57,
+          to: 63,
+        },
+        {
+          from: 72,
+          to: 79,
+        },
+      ],
+    },
+    leds: {
+      left: {
+        from: 0,
+        to: 34,
+      },
+      right: {
+        from: 35,
+        to: 69,
+      },
+    },
+  },
+  underglow: {
+    left: {
+      from: 70,
+      to: 122,
+    },
+    right: {
+      from: 123,
+      to: 175,
+    },
+  },
+};
+
+const raiseLayerMap: LayerMap = {
+  keys: {
+    position: {
+      left: [],
+      right: [],
+    },
+    leds: {
+      left: {
+        from: 0,
+        to: 0,
+      },
+      right: {
+        from: 0,
+        to: 0,
+      },
+    },
+  },
+  underglow: {
+    left: {
+      from: 0,
+      to: 0,
+    },
+    right: {
+      from: 0,
+      to: 0,
+    },
+  },
+};
+
+const raise2LayerMap: LayerMap = {
+  keys: {
+    position: {
+      left: [],
+      right: [],
+    },
+    leds: {
+      left: {
+        from: 0,
+        to: 0,
+      },
+      right: {
+        from: 0,
+        to: 0,
+      },
+    },
+  },
+  underglow: {
+    left: {
+      from: 0,
+      to: 0,
+    },
+    right: {
+      from: 0,
+      to: 0,
+    },
+  },
+};
+
+function getLayerMap(layer: string): LayerMap {
+  switch (layer) {
+    case "defy":
+      return defyLayerMap;
+    case "raise":
+      return raiseLayerMap;
+    case "raise2":
+      return raise2LayerMap;
+    default:
+      return defyLayerMap;
+  }
+}
+
+export default getLayerMap;

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -1946,6 +1946,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
           onConfirm={k => clearLayer(k.keyCode, k.colorIndex)}
           colors={palette}
           selectedColorIndex={palette.length - 1}
+          keyboardSide="BOTH"
           fillWithNoKey={false}
         />
 

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -1230,7 +1230,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     const idx = keymap.onlyCustom ? currentLayer : currentLayer - keymap.default.length;
     const keyCodeFiller = keymapDB.parse(fillKeyCode);
     const cloneLayer = [...newKeymap[idx]];
-
+    log.info(cloneLayer);
     if (chooseYourKeyboardSide === "LEFT") {
       layerMap.keys.position.left.forEach(value => {
         cloneLayer.fill(keyCodeFiller, value.from, value.to);
@@ -1246,12 +1246,14 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     if (chooseYourKeyboardSide === "BOTH") {
       cloneLayer.fill(keyCodeFiller);
     }
+    log.info(cloneLayer);
 
     newKeymap[idx] = cloneLayer;
 
     startContext();
     if (colorIndex >= 0) {
       const newColormap = colorMap.slice();
+      log.info(newColormap[idx]);
       if (newColormap.length > 0) {
         if (chooseYourKeyboardSide === "LEFT") {
           newColormap[idx].fill(colorIndex, layerMap.keys.leds.left.from, layerMap.keys.leds.left.to);
@@ -1266,6 +1268,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
         if (chooseYourKeyboardSide === "BOTH") {
           newColormap[idx] = Array(newColormap[0].length).fill(colorIndex);
         }
+        log.info(newColormap[idx]);
       }
       setColorMap(newColormap);
     }

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -54,6 +54,7 @@ import { i18n } from "@Renderer/i18n";
 import Store from "@Renderer/utils/Store";
 import getLanguage from "@Renderer/utils/language";
 import { ClearLayerDialog } from "@Renderer/components/molecules/CustomModal/ClearLayerDialog";
+import getLayerMap from "@Renderer/utils/LayersMap";
 import Keymap, { KeymapDB } from "../../api/keymap";
 import { rgb2w, rgbw2b } from "../../api/color";
 import Backup from "../../api/backup";
@@ -1224,54 +1225,21 @@ const LayoutEditor = (props: LayoutEditorProps) => {
   };
 
   const clearLayer = (fillKeyCode = TRANS_KEY_CODE, colorIndex = 15, chooseYourKeyboardSide = "BOTH") => {
-    log.info(state);
+    const layerMap = getLayerMap(deviceName.toLowerCase());
     const newKeymap = keymap.custom.slice();
     const idx = keymap.onlyCustom ? currentLayer : currentLayer - keymap.default.length;
     const keyCodeFiller = keymapDB.parse(fillKeyCode);
     const cloneLayer = [...newKeymap[idx]];
-    const dygmaMap = {
-      keys: {
-        left: [
-          0, 1, 2, 3, 4, 5, 6, 16, 17, 18, 19, 20, 21, 22, 32, 33, 34, 35, 36, 37, 38, 48, 49, 50, 51, 52, 53, 64, 65, 66, 67, 68,
-          69, 70, 71,
-        ],
-        right: [
-          9, 10, 11, 12, 13, 14, 15, 25, 26, 27, 28, 29, 30, 31, 41, 42, 43, 44, 45, 46, 47, 58, 59, 60, 61, 62, 63, 72, 73, 74,
-          75, 76, 77, 78, 79,
-        ],
-      },
-      leds: {
-        left: {
-          keys: {
-            from: 0,
-            to: 34,
-          },
-          underglow: {
-            from: 70,
-            to: 122,
-          },
-        },
-        right: {
-          keys: {
-            from: 35,
-            to: 69,
-          },
-          underglow: {
-            from: 123,
-            to: 175,
-          },
-        },
-      },
-    };
+
     if (chooseYourKeyboardSide === "LEFT") {
-      dygmaMap.keys.left.forEach(key => {
-        cloneLayer[key] = keyCodeFiller;
+      layerMap.keys.position.left.forEach(value => {
+        cloneLayer.fill(keyCodeFiller, value.from, value.to);
       });
     }
 
     if (chooseYourKeyboardSide === "RIGHT") {
-      dygmaMap.keys.right.forEach(key => {
-        cloneLayer[key] = keyCodeFiller;
+      layerMap.keys.position.right.forEach(value => {
+        cloneLayer.fill(keyCodeFiller, value.from, value.to);
       });
     }
 
@@ -1285,29 +1253,19 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     if (colorIndex >= 0) {
       const newColormap = colorMap.slice();
       if (newColormap.length > 0) {
-        log.info(newColormap[idx]);
         if (chooseYourKeyboardSide === "LEFT") {
-          newColormap[idx] = newColormap[idx].map((elem: number, index: number) =>
-            (dygmaMap.leds.left.keys.from <= index && index <= dygmaMap.leds.left.keys.to) ||
-            (dygmaMap.leds.left.underglow.from <= index && index <= dygmaMap.leds.left.underglow.to)
-              ? colorIndex
-              : elem,
-          );
+          newColormap[idx].fill(colorIndex, layerMap.keys.leds.left.from, layerMap.keys.leds.left.to);
+          newColormap[idx].fill(colorIndex, layerMap.underglow.left.from, layerMap.underglow.left.to);
         }
 
         if (chooseYourKeyboardSide === "RIGHT") {
-          newColormap[idx] = newColormap[idx].map((elem: number, index: number) =>
-            (dygmaMap.leds.right.keys.from <= index && index <= dygmaMap.leds.right.keys.to) ||
-            (dygmaMap.leds.right.underglow.from <= index && index <= dygmaMap.leds.right.underglow.to)
-              ? colorIndex
-              : elem,
-          );
+          newColormap[idx].fill(colorIndex, layerMap.keys.leds.right.from, layerMap.keys.leds.right.to);
+          newColormap[idx].fill(colorIndex, layerMap.underglow.right.from, layerMap.underglow.right.to);
         }
 
         if (chooseYourKeyboardSide === "BOTH") {
           newColormap[idx] = Array(newColormap[0].length).fill(colorIndex);
         }
-        log.info(newColormap[idx]);
       }
       setColorMap(newColormap);
     }

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -1224,28 +1224,53 @@ const LayoutEditor = (props: LayoutEditorProps) => {
   };
 
   const clearLayer = (fillKeyCode = TRANS_KEY_CODE, colorIndex = 15, chooseYourKeyboardSide = "BOTH") => {
+    log.info(state);
     const newKeymap = keymap.custom.slice();
     const idx = keymap.onlyCustom ? currentLayer : currentLayer - keymap.default.length;
     const keyCodeFiller = keymapDB.parse(fillKeyCode);
     const cloneLayer = [...newKeymap[idx]];
-    const dygmaKeymap = {
-      left: [
-        0, 1, 2, 3, 4, 5, 6, 16, 17, 18, 19, 20, 21, 22, 32, 33, 34, 35, 36, 37, 38, 48, 49, 50, 51, 52, 53, 64, 65, 66, 67, 68,
-        69, 70, 71,
-      ],
-      right: [
-        9, 10, 11, 12, 13, 14, 15, 25, 26, 27, 28, 29, 30, 31, 41, 42, 43, 44, 45, 46, 47, 58, 59, 60, 61, 62, 63, 72, 73, 74, 75,
-        76, 77, 78, 79,
-      ],
+    const dygmaMap = {
+      keys: {
+        left: [
+          0, 1, 2, 3, 4, 5, 6, 16, 17, 18, 19, 20, 21, 22, 32, 33, 34, 35, 36, 37, 38, 48, 49, 50, 51, 52, 53, 64, 65, 66, 67, 68,
+          69, 70, 71,
+        ],
+        right: [
+          9, 10, 11, 12, 13, 14, 15, 25, 26, 27, 28, 29, 30, 31, 41, 42, 43, 44, 45, 46, 47, 58, 59, 60, 61, 62, 63, 72, 73, 74,
+          75, 76, 77, 78, 79,
+        ],
+      },
+      leds: {
+        left: {
+          keys: {
+            from: 0,
+            to: 34,
+          },
+          underglow: {
+            from: 70,
+            to: 122,
+          },
+        },
+        right: {
+          keys: {
+            from: 35,
+            to: 69,
+          },
+          underglow: {
+            from: 123,
+            to: 175,
+          },
+        },
+      },
     };
     if (chooseYourKeyboardSide === "LEFT") {
-      dygmaKeymap.left.forEach(key => {
+      dygmaMap.keys.left.forEach(key => {
         cloneLayer[key] = keyCodeFiller;
       });
     }
 
     if (chooseYourKeyboardSide === "RIGHT") {
-      dygmaKeymap.right.forEach(key => {
+      dygmaMap.keys.right.forEach(key => {
         cloneLayer[key] = keyCodeFiller;
       });
     }
@@ -1260,7 +1285,29 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     if (colorIndex >= 0) {
       const newColormap = colorMap.slice();
       if (newColormap.length > 0) {
-        newColormap[idx] = Array(newColormap[0].length).fill(colorIndex);
+        log.info(newColormap[idx]);
+        if (chooseYourKeyboardSide === "LEFT") {
+          newColormap[idx] = newColormap[idx].map((elem: number, index: number) =>
+            (dygmaMap.leds.left.keys.from <= index && index <= dygmaMap.leds.left.keys.to) ||
+            (dygmaMap.leds.left.underglow.from <= index && index <= dygmaMap.leds.left.underglow.to)
+              ? colorIndex
+              : elem,
+          );
+        }
+
+        if (chooseYourKeyboardSide === "RIGHT") {
+          newColormap[idx] = newColormap[idx].map((elem: number, index: number) =>
+            (dygmaMap.leds.right.keys.from <= index && index <= dygmaMap.leds.right.keys.to) ||
+            (dygmaMap.leds.right.underglow.from <= index && index <= dygmaMap.leds.right.underglow.to)
+              ? colorIndex
+              : elem,
+          );
+        }
+
+        if (chooseYourKeyboardSide === "BOTH") {
+          newColormap[idx] = Array(newColormap[0].length).fill(colorIndex);
+        }
+        log.info(newColormap[idx]);
       }
       setColorMap(newColormap);
     }

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -1223,11 +1223,38 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     });
   };
 
-  const clearLayer = (fillKeyCode = TRANS_KEY_CODE, colorIndex = 15) => {
+  const clearLayer = (fillKeyCode = TRANS_KEY_CODE, colorIndex = 15, chooseYourKeyboardSide = "BOTH") => {
     const newKeymap = keymap.custom.slice();
     const idx = keymap.onlyCustom ? currentLayer : currentLayer - keymap.default.length;
     const keyCodeFiller = keymapDB.parse(fillKeyCode);
-    newKeymap[idx] = new Array(newKeymap[0].length).fill(keyCodeFiller);
+    const cloneLayer = [...newKeymap[idx]];
+    const dygmaKeymap = {
+      left: [
+        0, 1, 2, 3, 4, 5, 6, 16, 17, 18, 19, 20, 21, 22, 32, 33, 34, 35, 36, 37, 38, 48, 49, 50, 51, 52, 53, 64, 65, 66, 67, 68,
+        69, 70, 71,
+      ],
+      right: [
+        9, 10, 11, 12, 13, 14, 15, 25, 26, 27, 28, 29, 30, 31, 41, 42, 43, 44, 45, 46, 47, 58, 59, 60, 61, 62, 63, 72, 73, 74, 75,
+        76, 77, 78, 79,
+      ],
+    };
+    if (chooseYourKeyboardSide === "LEFT") {
+      dygmaKeymap.left.forEach(key => {
+        cloneLayer[key] = keyCodeFiller;
+      });
+    }
+
+    if (chooseYourKeyboardSide === "RIGHT") {
+      dygmaKeymap.right.forEach(key => {
+        cloneLayer[key] = keyCodeFiller;
+      });
+    }
+
+    if (chooseYourKeyboardSide === "BOTH") {
+      cloneLayer.fill(keyCodeFiller);
+    }
+
+    newKeymap[idx] = cloneLayer;
 
     startContext();
     if (colorIndex >= 0) {
@@ -1943,7 +1970,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
         <ClearLayerDialog
           open={clearConfirmationOpen}
           onCancel={cancelClear}
-          onConfirm={k => clearLayer(k.keyCode, k.colorIndex)}
+          onConfirm={k => clearLayer(k.keyCode, k.colorIndex, k.chooseYourKeyboardSide)}
           colors={palette}
           selectedColorIndex={palette.length - 1}
           keyboardSide="BOTH"


### PR DESCRIPTION
It is an improvement that allows selecting the entire keyboard or any of its sides to apply the layer cleaning.

![clearlayer](https://github.com/Dygmalab/Bazecor/assets/5620412/b957068e-4446-427e-8ad5-6b98d137ac36)

It will remain in draft, as if I get a bit more motivated, I will apply these improvements to the color application.
Any suggestions or corrections are welcome.
