### PR TITLE
fix: Select correct Superkey/Macro in Layout Editor

### DIFF
--- a/src/renderer/modules/KeysTabs/MacroTab.tsx
+++ b/src/renderer/modules/KeysTabs/MacroTab.tsx
@@ -57,6 +57,7 @@ const MacroTab = (props: MacroTabProps) => {
     return macrosContainer;
   });
 
+  const currentlySelectedMacroIndex = macros.length > 0 && props.keyCode.modified === 53852 ? String(props.keyCode.base) : undefined;
   return (
     <div
       className={`flex flex-wrap h-[inherit] ${isStandardView ? "standardViewTab" : ""} tabsMacro ${disabled ? "opacity-50 pointer-events-none" : ""}`}
@@ -90,11 +91,7 @@ const MacroTab = (props: MacroTabProps) => {
             {i18n.editor.macros.macroTab.label}
           </Heading>
           <Select
-            // value={
-            //   macrosAux.length > 0 && macrosAux[selected] !== undefined && macrosAux[selected].text
-            //     ? macrosAux[selected].value
-            //     : "Loading"
-            // }
+            value={currentlySelectedMacroIndex}
             onValueChange={isStandardView ? changeSelectedStd : changeSelected}
           >
             <SelectTrigger className="w-[280px]">

--- a/src/renderer/modules/KeysTabs/SuperkeysTab.tsx
+++ b/src/renderer/modules/KeysTabs/SuperkeysTab.tsx
@@ -166,7 +166,7 @@ const SuperkeysTab = ({ macros, keyCode, isStandardView, actions, onKeySelect, s
               {i18n.editor.standardView.superkeys.label}
             </Heading>
             <div className="superKeySelect">
-              <Select onValueChange={value => onKeySelect(parseInt(value, 10))}>
+              <Select onValueChange={value => onKeySelect(parseInt(value, 10))} value={superk.indexOf(KC) >= 0 ? String(KC) : undefined}>
                 <SelectTrigger className="w-[280px]">
                   <SelectValue placeholder="Select Superkey" />
                 </SelectTrigger>


### PR DESCRIPTION
Wrong selection could still occur by the following steps:
1) Select a key that does NOT have a Superkey/Macro
2) Assign a Superkey/Macro
3) Click another key which does NOT have a Superkey/Macro assigned.
Error: The Superkey/Macro set on the previous key is still selected.

Maybe related to: https://github.com/radix-ui/primitives/issues/3089

Signed-off-by: Lawrence Brooks <84.lbrooks@gmail.com>