### PR TITLE
fix: Select correct Superkey/Macro in Layout Editor

### DIFF
--- a/src/renderer/modules/KeysTabs/MacroTab.tsx
+++ b/src/renderer/modules/KeysTabs/MacroTab.tsx
@@ -57,6 +57,7 @@ const MacroTab = (props: MacroTabProps) => {
     return macrosContainer;
   });
 
+  const currentlySelectedMacroIndex = macros.length > 0 && props.keyCode.modified === 53852 ? String(props.keyCode.base) : undefined;
   return (
     <div
       className={`flex flex-wrap h-[inherit] ${isStandardView ? "standardViewTab" : ""} tabsMacro ${disabled ? "opacity-50 pointer-events-none" : ""}`}
@@ -90,11 +91,7 @@ const MacroTab = (props: MacroTabProps) => {
             {i18n.editor.macros.macroTab.label}
           </Heading>
           <Select
-            // value={
-            //   macrosAux.length > 0 && macrosAux[selected] !== undefined && macrosAux[selected].text
-            //     ? macrosAux[selected].value
-            //     : "Loading"
-            // }
+            value={currentlySelectedMacroIndex}
             onValueChange={isStandardView ? changeSelectedStd : changeSelected}
           >
             <SelectTrigger className="w-[280px]">

--- a/src/renderer/modules/KeysTabs/SuperkeysTab.tsx
+++ b/src/renderer/modules/KeysTabs/SuperkeysTab.tsx
@@ -166,7 +166,7 @@ const SuperkeysTab = ({ macros, keyCode, isStandardView, actions, onKeySelect, s
               {i18n.editor.standardView.superkeys.label}
             </Heading>
             <div className="superKeySelect">
-              <Select onValueChange={value => onKeySelect(parseInt(value, 10))}>
+              <Select onValueChange={value => onKeySelect(parseInt(value, 10))} value={superk.indexOf(KC) >= 0 ? String(KC) : undefined}>
                 <SelectTrigger className="w-[280px]">
                   <SelectValue placeholder="Select Superkey" />
                 </SelectTrigger>


### PR DESCRIPTION
**Found In**: Bazecor v1.5.2
**Found With**: Virtual Defy Keyboard

In the Layout Editor when a key with a Macro or Superkey assigned is clicked the description below the dropdown is correct, but the selected element in the dropdown is not correct.

### Steps to reproduce initial inaccuracy:
1. Assign a Macro (or Superkey) to a key in the Layout Editor
2. Click a different category of key functions (eg: Mouse)
3. Click back to the Macro (or Superkey) category.
* Expected: The dropdown selects the Macro/Superkey that is applied to the key
* Result: The dropdown now displays "Select Macro" (or Superkey) rather than the Macro/Superkey set on that key.


### Remaining Edge Case
This PR will select the correct value in the dropdown in most scenarios, but there is still one path (that I've found) that displays an incorrect value:
1. Select a key that does NOT have a Macro/Superkey
2. Assign a Macro/Superkey
3. Click another key which does NOT have a Macro/Superkey assigned.
* Expected: `Select Macro/Superkey` to be "selected" in the dropdown
* Error: The Superkey/Macro set on the previous key is still selected.

Maybe related to: https://github.com/radix-ui/primitives/issues/3089