### PR TITLE
fix: handle hex colors without a preceeding # and refactor

### DIFF
--- a/src/renderer/utils/colorDarkerCalculation.test.ts
+++ b/src/renderer/utils/colorDarkerCalculation.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import colorDarkerCalculation from "./colorDarkerCalculation";
+
+test.each([
+  { color: "#aABbcC", expected: "rgb(43, 94, 153)" },
+  { color: "aABbcC", expected: "rgb(43, 94, 153)" },
+  { color: "rGb(170, 187, 204)", expected: "rgb(43, 94, 153)" },
+  { color: "rGb(255, 255, 0)", expected: "rgb(64, 128, 0)" },
+  { color: "qwerty", expected: "rgb(0, 0, 0)" },
+])("colorDarkerCalculation($color) -> $expected", ({ color, expected }) => {
+  expect(colorDarkerCalculation(color)).toBe(expected);
+});

--- a/src/renderer/utils/colorDarkerCalculation.ts
+++ b/src/renderer/utils/colorDarkerCalculation.ts
@@ -1,48 +1,12 @@
-/* eslint-disable no-bitwise */
-export default function colorDarkerCalculation(color: string) {
-  // Functions to convert colors
-  function hexToRgb(hex: string) {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result
-      ? {
-          r: parseInt(result[1], 16),
-          g: parseInt(result[2], 16),
-          b: parseInt(result[3], 16),
-        }
-      : null;
-  }
-  // alert(hexToRgb("#0033ff").g); // "51";
+import { parseColor, RgbColor } from "./parseColor";
 
-  // alert(rgbToHex(0, 51, 255)); // #0033ff
-  // function rgbToHex(r, g, b) {
-  //   return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
-  // }
-  // alert(rgbToHex(0, 51, 255)); // #0033ff
-
-  const regexTestHEX = /^#([0-9a-f]{3}){1,2}$/i;
-
-  // Calc matrix color but you need to convert to RGB color first
-  const sumColor = (rgbColor: string) => {
-    const localRgbColor = rgbColor.replace(/[^\d,]/g, "").split(",");
-    const shadeDarkerInternal = `rgb(${(parseInt(localRgbColor[0], 10) * 0.25).toFixed(0)}, ${(
-      parseInt(localRgbColor[1], 10) * 0.5
-    ).toFixed(0)}, ${(parseInt(localRgbColor[2], 10) * 0.75).toFixed(0)} )`;
-    return shadeDarkerInternal;
-  };
-
-  let safeRGBColor;
-  let shadeDarker;
-
-  if (regexTestHEX.test(color)) {
-    // is Hexa
-    // console.log("Color is Hexa: ", color);
-    safeRGBColor = `rgb(${hexToRgb(color).r}, ${hexToRgb(color).g}, ${hexToRgb(color).b})`;
-    shadeDarker = sumColor(safeRGBColor);
-  } else {
-    // is rgba
-    // console.log("Color is RGB: ", color);
-    shadeDarker = sumColor(color);
-  }
-
-  return shadeDarker;
+/**
+ * Darken the supplied color
+ * @param {string} color A color in Hex or Rgb format
+ * @param {RgbColor} fallback The color to use if the supplied color cannot be parsed
+ * @returns {string} A darker version of the supplied color in rgb(#, #, #) format.
+ */
+export default function colorDarkerCalculation(color: string, fallback: RgbColor = { r: 0, g: 0, b: 0 }): string {
+  const parsedColor = parseColor(color, fallback);
+  return `rgb(${(parsedColor.r * 0.25).toFixed(0)}, ${(parsedColor.g * 0.5).toFixed(0)}, ${(parsedColor.b * 0.75).toFixed(0)})`;
 }

--- a/src/renderer/utils/colorMatricCalculation.test.ts
+++ b/src/renderer/utils/colorMatricCalculation.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import colorMatrixCalc from "./colorMatrixCalculation";
+
+test.each([
+  { color: "#aABbcC", opacity: 1, expected: "0 0 0 0 0.67 0 0 0 0 0.73 0 0 0 0 0.80 0 0 0 1 0" },
+  { color: "aABbcC", opacity: 1, expected: "0 0 0 0 0.67 0 0 0 0 0.73 0 0 0 0 0.80 0 0 0 1 0" },
+  { color: "rGb(170, 187, 204)", opacity: 1, expected: "0 0 0 0 0.67 0 0 0 0 0.73 0 0 0 0 0.80 0 0 0 1 0" },
+  { color: "rGb(255, 255, 0)", opacity: 0.65, expected: "0 0 0 0 1.00 0 0 0 0 1.00 0 0 0 0 0.00 0 0 0 0.65 0" },
+  { color: "qwerty", opacity: 0, expected: "0 0 0 0 0.00 0 0 0 0 0.00 0 0 0 0 0.00 0 0 0 0 0" },
+])("colorMatrixCalc($color, $opacity) -> $expected", ({ color, opacity, expected }) => {
+  expect(colorMatrixCalc(color, opacity)).toBe(expected);
+});

--- a/src/renderer/utils/colorMatrixCalculation.ts
+++ b/src/renderer/utils/colorMatrixCalculation.ts
@@ -1,48 +1,18 @@
-/* eslint-disable no-bitwise */
-export default function colorMatrixCalc(color: string, opacity: number) {
-  // Functions to convert colors
-  function hexToRgb(hex: string) {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result
-      ? {
-          r: parseInt(result[1], 16),
-          g: parseInt(result[2], 16),
-          b: parseInt(result[3], 16),
-        }
-      : null;
-  }
-  // alert(hexToRgb("#0033ff").g); // "51";
+import { parseColor, RgbColor } from "./parseColor";
 
-  // alert(rgbToHex(0, 51, 255)); // #0033ff
-  // function rgbToHex(r, g, b) {
-  //   return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
-  // }
-  // alert(rgbToHex(0, 51, 255)); // #0033ff
-
-  const regexTestHEX = /^#([0-9a-f]{3}){1,2}$/i;
-
-  // Calc matrix color but you need to convert to RGB color first
-  const calMatrix = (rgbColor: string, calOpacity: number) => {
-    const localRgbColor = rgbColor.replace(/[^\d,]/g, "").split(",");
-    const matrixColorInternal = `0 0 0 0 ${(parseInt(localRgbColor[0], 10) / 255).toFixed(2)} 0 0 0 0 ${(
-      parseInt(localRgbColor[1], 10) / 255
-    ).toFixed(2)} 0 0 0 0 ${(parseInt(localRgbColor[2], 10) / 255).toFixed(2)} 0 0 0 ${calOpacity} 0`;
-    return matrixColorInternal;
-  };
-
-  let safeRGBColor;
-  let matrixColor;
-
-  if (regexTestHEX.test(color)) {
-    // is Hexa
-    // console.log("Color is Hexa: ", color);
-    safeRGBColor = `rgb(${hexToRgb(color).r}, ${hexToRgb(color).g}, ${hexToRgb(color).b})`;
-    matrixColor = calMatrix(safeRGBColor, opacity);
-  } else {
-    // is rgba
-    // console.log("Color is RGB: ", color);
-    matrixColor = calMatrix(color, opacity);
-  }
-
-  return matrixColor;
+/**
+ * Darken the supplied color
+ * @param {string} color A color in Hex or Rgb format
+ * @param {number} opacity The opacity level of the color [0..1]
+ * @param {RgbColor} fallback The color to use if the supplied color cannot be parsed
+ * @returns {string} A matric version of the supplied color
+ */
+export default function colorMatrixCalc(color: string, opacity: number, fallback: RgbColor = { r: 0, g: 0, b: 0 }): string {
+  const parsedColor = parseColor(color, fallback);
+  return (
+    `0 0 0 0 ${(parsedColor.r / 255).toFixed(2)} ` +
+    `0 0 0 0 ${(parsedColor.g / 255).toFixed(2)} ` +
+    `0 0 0 0 ${(parsedColor.b / 255).toFixed(2)} ` +
+    `0 0 0 ${opacity} 0`
+  );
 }

--- a/src/renderer/utils/parseColor.test.ts
+++ b/src/renderer/utils/parseColor.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { parseColor } from "./parseColor";
+
+const fallback = { r: 1, g: 1, b: 1 };
+
+test.each([
+  { color: "#qqqqqq" },
+  { color: "rGb(-1, 0, 0)" },
+  { color: "rGb(0, -1, 0)" },
+  { color: "rGb(0, 0, -1)" },
+  { color: "rGb(256, 0, 0)" },
+  { color: "rGb(0, 256, 0)" },
+  { color: "rGb(0, 0, 256)" },
+])("invalid input to parseColor($color) returns fallback", ({ color }) => {
+  expect(parseColor(color, fallback)).toStrictEqual(fallback);
+});
+
+test.each([
+  { color: "#aABbcC", expected: { r: 170, g: 187, b: 204 } },
+  { color: "aABbcC", expected: { r: 170, g: 187, b: 204 } },
+  { color: "rGb(170, 187, 204)", expected: { r: 170, g: 187, b: 204 } },
+])("valid input to parseColor($color) returns color", ({ color, expected }) => {
+  expect(parseColor(color, fallback)).toStrictEqual(expected);
+});

--- a/src/renderer/utils/parseColor.ts
+++ b/src/renderer/utils/parseColor.ts
@@ -1,0 +1,42 @@
+export interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/**
+ * Parse the supplied color to it's component R, G, B values.
+ * @param {string} color A color in Hex or Rgb format
+ * @param {RgbColor} fallback The color to use if the supplied color cannot be parsed.
+ * @returns {RgbColor} The color converted to an object containing the three color values.
+ */
+export function parseColor(color: string, fallback: RgbColor): RgbColor {
+  const hexRegex = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i;
+  const rgbRegex = /^rgb\(([\d]+), ([\d]+), ([\d]+)\)$/i;
+
+  function parseRgbColor(input: string, regex: RegExp, numberBase: number) {
+    const result = regex.exec(input);
+    return {
+      r: parseInt(result[1], numberBase),
+      g: parseInt(result[2], numberBase),
+      b: parseInt(result[3], numberBase),
+    };
+  }
+
+  let result: RgbColor;
+  if (hexRegex.test(color)) {
+    result = parseRgbColor(color, hexRegex, 16);
+  } else if (rgbRegex.test(color)) {
+    result = parseRgbColor(color, rgbRegex, 10);
+  } else {
+    // Supplied color could not be parsed
+    return fallback;
+  }
+
+  if (result.r < 0 || result.r > 255 || result.g < 0 || result.g > 255 || result.b < 0 || result.b > 255) {
+    // Some color values are out of bounds
+    return fallback;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Two edge cases for this two functions would result in NaN being contained within the returned color matrix:

Supplying a hex color string without a preceeding #
Supplying a string that was not in the hex or rgb color format.

This PR covers those two cases by:
- Supporting hex colors without a preceeding #
- Defaults to black if the input string is neither a hex or rgb color

Additionally this PR also
- Eliminates the double call to parseInt when supplying a hex color
- Added test coverage
- Refactored out the common used method to de-duplicate