### PR TITLE
fix: Invalid RGBW returned for invalid RGBW received

### DIFF
--- a/src/api/arrayFillNum.test.ts
+++ b/src/api/arrayFillNum.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+import aFN from "./arrayFillNum";
+
+test.each([
+  { start: 1, end: 1, expected: [] },
+  { start: 1, end: 3, expected: [1, 2] },
+  { start: 3, end: 1, expected: [] },
+  { start: -1, end: -1, expected: [] },
+  { start: -1, end: -3, expected: [] },
+  { start: -3, end: -1, expected: [-3, -2] },
+  { start: -3, end: 3, expected: [-3, -2, -1, 0, 1, 2] },
+])("aFN($start, $end) = $expected", ({ start, end, expected }) => {
+  expect(aFN(start, end)).toStrictEqual(expected);
+});

--- a/src/api/arrayFillNum.ts
+++ b/src/api/arrayFillNum.ts
@@ -2,11 +2,13 @@
  * Function that returns an array of numbers from start to end.
  * @param {number} start - The number to start from.
  * @param {number} end - The number to end at.
- * @returns {Array<number>} - An array of numbers from start to end.
+ * @returns {Array<number>} - An array of numbers from start to end if end is greater than start. Otherwise returns an empty array.
  * @example
  * const arr = aFN(1, 5);
  */
 export default function aFN(start: number, end: number): Array<number> {
-  const arr = Array.from({ length: end - start }, (e, i) => i + start);
-  return arr;
+  if (start === end || end < start) {
+    return [];
+  }
+  return Array.from({ length: end - start }, (e, i) => i + start);
 }

--- a/src/api/color/RGBWtoRGB.test.ts
+++ b/src/api/color/RGBWtoRGB.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+import { rgbw2b } from "./RGBWtoRGB";
+
+test.each([
+  { input: { r: 10, g: 20, b: 30, w: 40 }, expected: { r: 50, g: 60, b: 70, rgb: "rgb(50, 60, 70)" } },
+  { input: { r: 10, g: 20, b: 30, w: -40 }, expected: { r: 10, g: 20, b: 30, rgb: "rgb(10, 20, 30)" } },
+  { input: { r: 10, g: 20, b: 30, w: 1000 }, expected: { r: 255, g: 255, b: 255, rgb: "rgb(255, 255, 255)" } },
+  { input: { r: 100, g: 20, b: 30, w: 200 }, expected: { r: 255, g: 220, b: 230, rgb: "rgb(255, 220, 230)" } },
+])("rgbw2b($input) = $expected", ({ input, expected }) => {
+  expect(rgbw2b(input)).toEqual(expected);
+});

--- a/src/api/color/RGBWtoRGB.ts
+++ b/src/api/color/RGBWtoRGB.ts
@@ -1,16 +1,20 @@
-type RGBW = {
-  r: number;
-  g: number;
-  b: number;
-  w: number;
-};
+import { sanitizeIntensity } from "./sanitizeIntensity";
+import { RGB, RGBW } from "./types";
 
-export default function rgbw2b(rgbw: RGBW) {
-  const r = rgbw.w + rgbw.r > 255 ? 255 : rgbw.w + rgbw.r;
-  const g = rgbw.w + rgbw.g > 255 ? 255 : rgbw.w + rgbw.g;
-  const b = rgbw.w + rgbw.b > 255 ? 255 : rgbw.w + rgbw.b;
+/**
+ * Convert a RGBW color to RGB
+ * @param {RGBW} color - A RGBW color
+ * @returns {RGB} - The color converted to RGB
+ */
+export function rgbw2b(color: RGBW): RGB {
+  const sanitizedR = sanitizeIntensity(color.r);
+  const sanitizedG = sanitizeIntensity(color.g);
+  const sanitizedB = sanitizeIntensity(color.b);
+  const sanitizedW = sanitizeIntensity(color.w);
 
-  const result = `rgb(${r}, ${g}, ${b})`;
+  const r = sanitizeIntensity(sanitizedW + sanitizedR);
+  const g = sanitizeIntensity(sanitizedW + sanitizedG);
+  const b = sanitizeIntensity(sanitizedW + sanitizedB);
 
-  return { r, g, b, rgb: result };
+  return { r, g, b, rgb: `rgb(${r}, ${g}, ${b})` };
 }

--- a/src/api/color/RGBtoRGBW.test.ts
+++ b/src/api/color/RGBtoRGBW.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+import { rgb2w } from "./RGBtoRGBW";
+
+test.each([
+  { input: { r: 0, g: 0, b: 0 }, expected: { r: 0, g: 0, b: 0, w: 0 } },
+  { input: { r: 100, g: 200, b: 250 }, expected: { r: 0, g: 100, b: 150, w: 100 } },
+  { input: { r: -100, g: 100, b: 200 }, expected: { r: 0, g: 100, b: 200, w: 0 } },
+])("rgb2w($input) = $expected", ({ input, expected }) => {
+  expect(rgb2w(input)).toEqual(expected);
+});

--- a/src/api/color/RGBtoRGBW.ts
+++ b/src/api/color/RGBtoRGBW.ts
@@ -1,21 +1,22 @@
-type RGB = {
-  r: number;
-  g: number;
-  b: number;
-};
+import { sanitizeIntensity } from "./sanitizeIntensity";
+import { RGB, RGBW } from "./types";
 
-export default function rgb2w(rgb: RGB) {
-  const Ri = rgb.r;
-  const Gi = rgb.g;
-  const Bi = rgb.b;
-  const minVal = Math.min(Ri, Math.min(Gi, Bi));
+/**
+ * Convert a RGB color to RGBW
+ * @param {RGB} color - A RGB color
+ * @returns {RGBW} - The color converted to RGBW
+ */
+export function rgb2w(color: RGB): RGBW {
+  const sanitizedR = sanitizeIntensity(color.r);
+  const sanitizedG = sanitizeIntensity(color.g);
+  const sanitizedB = sanitizeIntensity(color.b);
 
-  const w = minVal;
-  const b = Bi - minVal;
-  const r = Ri - minVal;
-  const g = Gi - minVal;
+  const minVal = Math.min(sanitizedR, Math.min(sanitizedG, sanitizedB));
 
-  const result = { r, g, b, w };
-
-  return result;
+  return {
+    r: sanitizedR - minVal,
+    b: sanitizedB - minVal,
+    g: sanitizedG - minVal,
+    w: minVal,
+  };
 }

--- a/src/api/color/index.ts
+++ b/src/api/color/index.ts
@@ -1,4 +1,6 @@
-import rgb2w from "./RGBtoRGBW";
-import rgbw2b from "./RGBWtoRGB";
+import { rgb2w } from "./RGBtoRGBW";
+import { rgbw2b } from "./RGBWtoRGB";
+import { sanitizeIntensity } from "./sanitizeIntensity";
+import { RGB, RGBW } from "./types";
 
-export { rgb2w, rgbw2b };
+export { rgb2w, rgbw2b, sanitizeIntensity, RGB, RGBW };

--- a/src/api/color/sanitizeIntensity.test.ts
+++ b/src/api/color/sanitizeIntensity.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import { sanitizeIntensity } from "./sanitizeIntensity";
+
+test.each([
+  { input: -100, expected: 0 },
+  { input: 0, expected: 0 },
+  { input: 100, expected: 100 },
+  { input: 255, expected: 255 },
+  { input: 1000, expected: 255 },
+])("sanitizeIntensity($input) = $expected", ({ input, expected }) => {
+  expect(sanitizeIntensity(input)).toEqual(expected);
+});

--- a/src/api/color/sanitizeIntensity.ts
+++ b/src/api/color/sanitizeIntensity.ts
@@ -1,0 +1,8 @@
+/**
+ * Ensure that a given number is within [0,255]. If lower, coerce to 0. If higher, coerce to 255.
+ * @param {number} value - An intensity value to sanitize
+ * @returns {number} - If value is < 0, then 0. If value is > 255, then 255. Otherwise value.
+ */
+export function sanitizeIntensity(value: number): number {
+  return Math.max(0, Math.min(255, value));
+}

--- a/src/api/color/types.ts
+++ b/src/api/color/types.ts
@@ -1,0 +1,13 @@
+export interface RGB {
+  r: number;
+  g: number;
+  b: number;
+  rgb?: string;
+}
+
+export interface RGBW {
+  r: number;
+  g: number;
+  b: number;
+  w: number;
+}


### PR DESCRIPTION
The RGB to/from RGBW methods could return intensity values outside of the valid range [0,255] if the method received values outside of that range.

In this PR:
* Fixes to coerce inputs outside of the valid range to appropriate min/max valid value
* Minor cleanup to arrayFillNumber to make it clearer that end must be greater than start
* Added documentation comments for exported methods
* Added tests