### PR TITLE
cleanup: Consolidate to a single `delay` method.

### DIFF
--- a/src/api/comms/Device.ts
+++ b/src/api/comms/Device.ts
@@ -95,11 +95,6 @@ class Device implements DeviceClass {
     }
   }
 
-  static delay = (ms: number) =>
-    new Promise(res => {
-      setTimeout(res, ms);
-    });
-
   static getHWFVirtual = (dev: DygmaDeviceType) => {
     let result: DygmaDeviceType;
     Hardware.serial.forEach(hdev => {

--- a/src/api/flash/RaiseTools.ts
+++ b/src/api/flash/RaiseTools.ts
@@ -2,7 +2,7 @@
 import log from "electron-log/renderer";
 import type { SerialPort as SP } from "serialport";
 import { DygmaDeviceType } from "@Renderer/types/dygmaDefs";
-import { delay } from "./delay";
+import { delay } from "../../main/utils/delay";
 import { findDevice } from "./findDevice";
 import Device from "../comms/Device";
 import { arduino } from "./raiseFlasher/arduino-flasher";

--- a/src/api/flash/defyFlasher/NRf52833-flasher.ts
+++ b/src/api/flash/defyFlasher/NRf52833-flasher.ts
@@ -22,7 +22,7 @@ import { serialConnection, rawCommand, noWaitCommand } from "../serialConnection
 import { PACKET_SIZE, TYPE_DAT, TYPE_ELA, TYPE_ESA } from "../flasherConstants";
 import { HexType } from "../types";
 import ihexDecode from "../ihexDecode";
-import { delay } from "../delay";
+import { delay } from "../../../main/utils/delay";
 
 let serialPort;
 

--- a/src/api/flash/defyFlasher/flash.ts
+++ b/src/api/flash/defyFlasher/flash.ts
@@ -22,7 +22,7 @@ import { DeviceClass } from "@Renderer/types/devices";
 import { DeviceTools } from "@Renderer/DeviceContext";
 import Device, { State } from "src/api/comms/Device";
 import Hardware from "../../hardware";
-import { delay } from "../delay";
+import { delay } from "../../../main/utils/delay";
 import NRf52833 from "./NRf52833-flasher";
 
 class FlashDefyWireless {

--- a/src/api/flash/defyFlasher/rp2040-flasher.ts
+++ b/src/api/flash/defyFlasher/rp2040-flasher.ts
@@ -19,7 +19,7 @@ import log from "electron-log/renderer";
 import fs from "fs";
 import * as path from "path";
 import SideFlaser from "./sideFlasher";
-import { delay } from "../delay";
+import { delay } from "../../../main/utils/delay";
 
 /**
  * Object rp2040 with flash method.

--- a/src/api/flash/defyFlasher/sideFlasher.ts
+++ b/src/api/flash/defyFlasher/sideFlasher.ts
@@ -33,7 +33,7 @@
 import { crc32 } from "easy-crc";
 import log from "electron-log/renderer";
 import type { PortInfo } from "@serialport/bindings-cpp";
-import { delay } from "../delay";
+import { delay } from "../../../main/utils/delay";
 
 const { SerialPort } = eval('require("serialport")');
 const { DelimiterParser } = eval('require("@serialport/parser-delimiter")');

--- a/src/api/flash/raiseFlasher/flash.js
+++ b/src/api/flash/raiseFlasher/flash.js
@@ -20,7 +20,7 @@ import path from "path";
 import log from "electron-log/renderer";
 import Focus from "../../focus";
 import Hardware from "../../hardware";
-import { delay } from "../delay";
+import { delay } from "../../../main/utils/delay";
 import formatedDate from "../formatedDate";
 import { arduino } from "./arduino-flasher";
 

--- a/src/api/flash/serialConnection.ts
+++ b/src/api/flash/serialConnection.ts
@@ -7,7 +7,7 @@ import type { PortInfo } from "@serialport/bindings-cpp";
 import log from "electron-log/renderer";
 import { DygmaDeviceType } from "@Renderer/types/dygmaDefs";
 import type { SerialPort as SP } from "serialport";
-import { delay } from "./delay";
+import { delay } from "../../main/utils/delay";
 import { InfoType } from "./types";
 import Hardware from "../hardware";
 

--- a/src/api/focus/Focus.ts
+++ b/src/api/focus/Focus.ts
@@ -26,7 +26,7 @@ import log from "electron-log/renderer";
 // eslint-disable-next-line import/no-cycle
 import { DygmaDeviceType } from "@Renderer/types/dygmaDefs";
 import { VirtualType } from "@Renderer/types/virtual";
-import { delay } from "../flash/delay";
+import { delay } from "../../main/utils/delay";
 import { ctx } from "./Focus.ctx";
 
 // TODO: any reason we can't import directly?

--- a/src/main/utils/delay.test.ts
+++ b/src/main/utils/delay.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, Mock } from 'vitest';
-import delay from "./delay";
+import { delay } from "./delay";
 
 describe('delayed execution', () => {
   let mock: Mock;

--- a/src/main/utils/delay.ts
+++ b/src/main/utils/delay.ts
@@ -1,5 +1,7 @@
-function delay(timeInMs: number) {
+/**
+ * Waits the specified amount of milliseconds
+ * @param {number} timeInMs - The amount of time to wait in milliseconds
+ */
+export function delay(timeInMs: number) {
   return new Promise(resolve => setTimeout(resolve, timeInMs));
 }
-
-export default delay;

--- a/src/main/utils/listDrivesHandler.ts
+++ b/src/main/utils/listDrivesHandler.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-loop-func */
 /* eslint-disable no-await-in-loop */
 import log from "electron-log/main";
-import delay from "./delay";
+import { delay } from "./delay";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const drivelist = require("drivelist");

--- a/src/renderer/controller/FlashingProcedure/actions.ts
+++ b/src/renderer/controller/FlashingProcedure/actions.ts
@@ -12,12 +12,8 @@ import NRf52833 from "../../../api/flash/defyFlasher/NRf52833-flasher";
 import SideFlaser from "../../../api/flash/defyFlasher/sideFlasher";
 import Raise2Flash from "../../../api/flash/raise2Flasher/Raise2-flasher";
 import { FlashRaise } from "../../../api/flash";
+import { delay } from "../../../main/utils/delay";
 import * as Context from "./context";
-
-const delay = (ms: number) =>
-  new Promise(res => {
-    setTimeout(res, ms);
-  });
 
 const stateUpdate = (stage: string, percentage: number, context: Context.ContextType) => {
   log.info(stage, percentage);


### PR DESCRIPTION
The delay method was declared in 3 or 4 different places. Consolidate to one of the two importable functions and use it wherever the delay is needed.