### PR TITLE
feat: add undo/redo functionality to editors

### DIFF
--- a/src/renderer/components/atoms/icons/IconRedo.tsx
+++ b/src/renderer/components/atoms/icons/IconRedo.tsx
@@ -1,0 +1,34 @@
+/* Bazecor
+ * Copyright (C) 2024  Dygmalab, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+function IconRedo() {
+  return (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M20 9H9a5 5 0 000 10h6"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M16 5l4 4-4 4" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export default IconRedo;

--- a/src/renderer/components/atoms/icons/IconUndo.tsx
+++ b/src/renderer/components/atoms/icons/IconUndo.tsx
@@ -1,0 +1,34 @@
+/* Bazecor
+ * Copyright (C) 2024  Dygmalab, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as React from "react";
+
+function IconUndo() {
+  return (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M4 9h11a5 5 0 010 10H9"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M8 5L4 9l4 4" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export default IconUndo;

--- a/src/renderer/components/atoms/icons/index.tsx
+++ b/src/renderer/components/atoms/icons/index.tsx
@@ -131,6 +131,8 @@ import IconToolsCalculator from "./IconToolsCalculator";
 import IconToolsCamera from "./IconToolsCamera";
 import IconToolsEject from "./IconToolsEject";
 import IconTypo from "./IconTypo";
+import IconUndo from "./IconUndo";
+import IconRedo from "./IconRedo";
 import IconUndoRestart from "./IconUndoRestart";
 import IconUpload from "./IconUpload";
 import IconUSB from "./IconUSB";
@@ -257,6 +259,8 @@ export {
   IconToolsCamera,
   IconToolsEject,
   IconTypo,
+  IconUndo,
+  IconRedo,
   IconUndoRestart,
   IconUpload,
   IconUSB,

--- a/src/renderer/modules/PageHeader/PageHeader.tsx
+++ b/src/renderer/modules/PageHeader/PageHeader.tsx
@@ -18,6 +18,8 @@
 import React from "react";
 import Styled from "styled-components";
 import Heading from "@Renderer/components/atoms/Heading";
+import { Button } from "@Renderer/components/atoms/Button";
+import { IconUndo, IconRedo } from "@Renderer/components/atoms/icons";
 import { PageHeaderType } from "./Types";
 import Saving from "../Saving";
 
@@ -109,6 +111,10 @@ function PageHeader(props: PageHeaderType) {
     secondaryButton,
     saveButtonRef,
     discardChangesButtonRef,
+    onUndo,
+    onRedo,
+    canUndo,
+    canRedo,
   } = props;
   return (
     <Style className={`${styles === "pageHeaderFlatBottom" ? "pageHeaderSticky" : ""}`}>
@@ -122,6 +128,28 @@ function PageHeader(props: PageHeaderType) {
         </div>
         <div className="pageTools">
           {contentSelector || ""}
+          {onUndo && onRedo && (
+            <div className="flex gap-1 mr-2">
+              <Button
+                onClick={onUndo}
+                variant="ghost"
+                size="icon"
+                disabled={!canUndo || isSaving}
+                title="Undo (Ctrl+Z)"
+              >
+                <IconUndo />
+              </Button>
+              <Button
+                onClick={onRedo}
+                variant="ghost"
+                size="icon"
+                disabled={!canRedo || isSaving}
+                title="Redo (Ctrl+Y)"
+              >
+                <IconRedo />
+              </Button>
+            </div>
+          )}
           {showSaving ? (
             <Saving
               saveContext={saveContext}

--- a/src/renderer/modules/PageHeader/Types.ts
+++ b/src/renderer/modules/PageHeader/Types.ts
@@ -16,4 +16,8 @@ export interface PageHeaderType {
   secondaryButton?: React.ReactNode;
   saveButtonRef?: React.RefObject<HTMLButtonElement>;
   discardChangesButtonRef?: React.RefObject<HTMLButtonElement>;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
 }

--- a/src/renderer/types/history.ts
+++ b/src/renderer/types/history.ts
@@ -1,0 +1,31 @@
+/* Bazecor
+ * Copyright (C) 2024  DygmaLab SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface HistoryState<T> {
+  past: T[];
+  present: T;
+  future: T[];
+}
+
+export interface UseHistoryReturn<T> {
+  state: T;
+  setState: (newState: T | ((prev: T) => T)) => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  reset: (newPresent: T) => void;
+}

--- a/src/renderer/utils/useHistory.test.ts
+++ b/src/renderer/utils/useHistory.test.ts
@@ -1,0 +1,203 @@
+/* Bazecor
+ * Copyright (C) 2024  DygmaLab SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useHistory from "./useHistory";
+
+describe("useHistory", () => {
+  it("should initialize with the provided state", () => {
+    const { result } = renderHook(() => useHistory({ value: 1 }));
+
+    expect(result.current.state).toEqual({ value: 1 });
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("should update state and track history", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.setState(1);
+    });
+
+    expect(result.current.state).toBe(1);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("should undo to previous state", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.setState(1);
+      result.current.setState(2);
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.state).toBe(1);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(true);
+  });
+
+  it("should redo to next state", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.setState(1);
+      result.current.setState(2);
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    act(() => {
+      result.current.redo();
+    });
+
+    expect(result.current.state).toBe(2);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("should clear future on new state change", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.setState(1);
+      result.current.setState(2);
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.setState(3);
+    });
+
+    expect(result.current.state).toBe(3);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("should not add to history if state is identical", () => {
+    const { result } = renderHook(() => useHistory(1));
+
+    act(() => {
+      result.current.setState(1);
+    });
+
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("should reset history with new present value", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.setState(1);
+      result.current.setState(2);
+    });
+
+    act(() => {
+      result.current.reset(10);
+    });
+
+    expect(result.current.state).toBe(10);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("should limit history to 50 entries", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      for (let i = 1; i <= 60; i += 1) {
+        result.current.setState(i);
+      }
+    });
+
+    expect(result.current.state).toBe(60);
+
+    let undoCount = 0;
+    while (result.current.canUndo) {
+      act(() => {
+        result.current.undo();
+      });
+      undoCount += 1;
+    }
+
+    expect(undoCount).toBe(50);
+    expect(result.current.state).toBe(10);
+  });
+
+  it("should support functional updates", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.setState(prev => prev + 1);
+      result.current.setState(prev => prev + 1);
+    });
+
+    expect(result.current.state).toBe(2);
+    expect(result.current.canUndo).toBe(true);
+  });
+
+  it("should not undo past beginning", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.state).toBe(0);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("should not redo past end", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.redo();
+    });
+
+    expect(result.current.state).toBe(0);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("should work with complex objects", () => {
+    const initial = { keymap: [[1, 2]], colors: ["red"] };
+    const { result } = renderHook(() => useHistory(initial));
+
+    const updated = { keymap: [[3, 4]], colors: ["blue"] };
+    act(() => {
+      result.current.setState(updated);
+    });
+
+    expect(result.current.state).toEqual(updated);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.state).toEqual(initial);
+  });
+});

--- a/src/renderer/utils/useHistory.ts
+++ b/src/renderer/utils/useHistory.ts
@@ -1,0 +1,110 @@
+/* Bazecor
+ * Copyright (C) 2024  DygmaLab SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState, useCallback } from "react";
+import { HistoryState, UseHistoryReturn } from "@Types/history";
+
+const MAX_HISTORY_SIZE = 50;
+
+/**
+ * A hook that wraps state with undo/redo functionality.
+ * Maintains a fixed-size history stack (max 50 entries).
+ *
+ * @param initialState - The initial state value
+ * @returns Object with state, setState, undo, redo, and history status
+ */
+function useHistory<T>(initialState: T): UseHistoryReturn<T> {
+  const [history, setHistory] = useState<HistoryState<T>>({
+    past: [],
+    present: initialState,
+    future: [],
+  });
+
+  const setState = useCallback((newState: T | ((prev: T) => T)) => {
+    setHistory(current => {
+      const nextState = typeof newState === "function" ? (newState as (prev: T) => T)(current.present) : newState;
+
+      if (nextState === current.present) {
+        return current;
+      }
+
+      const newPast = [...current.past, current.present];
+      if (newPast.length > MAX_HISTORY_SIZE) {
+        newPast.shift();
+      }
+
+      return {
+        past: newPast,
+        present: nextState,
+        future: [],
+      };
+    });
+  }, []);
+
+  const undo = useCallback(() => {
+    setHistory(current => {
+      if (current.past.length === 0) {
+        return current;
+      }
+
+      const previous = current.past[current.past.length - 1];
+      const newPast = current.past.slice(0, -1);
+
+      return {
+        past: newPast,
+        present: previous,
+        future: [current.present, ...current.future],
+      };
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    setHistory(current => {
+      if (current.future.length === 0) {
+        return current;
+      }
+
+      const next = current.future[0];
+      const newFuture = current.future.slice(1);
+
+      return {
+        past: [...current.past, current.present],
+        present: next,
+        future: newFuture,
+      };
+    });
+  }, []);
+
+  const reset = useCallback((newPresent: T) => {
+    setHistory({
+      past: [],
+      present: newPresent,
+      future: [],
+    });
+  }, []);
+
+  return {
+    state: history.present,
+    setState,
+    undo,
+    redo,
+    canUndo: history.past.length > 0,
+    canRedo: history.future.length > 0,
+    reset,
+  };
+}
+
+export default useHistory;

--- a/src/renderer/utils/useUndoRedoKeys.ts
+++ b/src/renderer/utils/useUndoRedoKeys.ts
@@ -1,0 +1,55 @@
+/* Bazecor
+ * Copyright (C) 2024  DygmaLab SE.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from "react";
+
+/**
+ * Hook that listens for Ctrl+Z (undo) and Ctrl+Y / Ctrl+Shift+Z (redo) keyboard shortcuts.
+ * Works on both Windows/Linux (Ctrl) and macOS (Cmd).
+ *
+ * @param onUndo - Callback fired when undo shortcut is pressed
+ * @param onRedo - Callback fired when redo shortcut is pressed
+ * @param enabled - Whether shortcuts should be active (default: true)
+ */
+function useUndoRedoKeys(onUndo: () => void, onRedo: () => void, enabled = true): void {
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+      const modifier = isMac ? event.metaKey : event.ctrlKey;
+
+      if (!modifier) {
+        return;
+      }
+
+      if (event.key === "z" && !event.shiftKey) {
+        event.preventDefault();
+        onUndo();
+      } else if (event.key === "y" || (event.key === "z" && event.shiftKey)) {
+        event.preventDefault();
+        onRedo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onUndo, onRedo, enabled]);
+}
+
+export default useUndoRedoKeys;

--- a/src/renderer/views/LayoutEditor.tsx
+++ b/src/renderer/views/LayoutEditor.tsx
@@ -52,6 +52,8 @@ import { i18n } from "@Renderer/i18n";
 
 import Store from "@Renderer/utils/Store";
 import getLanguage from "@Renderer/utils/language";
+import useHistory from "@Renderer/utils/useHistory";
+import useUndoRedoKeys from "@Renderer/utils/useUndoRedoKeys";
 import { ClearLayerDialog } from "@Renderer/components/molecules/CustomModal/ClearLayerDialog";
 import { DygmaDeviceInfoType } from "@Renderer/types/dygmaDefs";
 import BlankTable from "../../api/keymap/db/blanks";
@@ -468,13 +470,20 @@ const LayoutEditor = (props: LayoutEditorProps) => {
   const [neuronID, setNeuronID] = useState("");
   const [currentKeyIndex, setCurrentKeyIndex] = useState(-1);
   const [currentLedIndex, setCurrentLedIndex] = useState(-1);
-  const [keymap, setKeymap] = useState<KeymapType>({
+  const keymapHistory = useHistory<KeymapType>({
     custom: [],
     default: [],
     onlyCustom: false,
   });
-  const [palette, setPalette] = useState([]);
-  const [colorMap, setColorMap] = useState([]);
+  const paletteHistory = useHistory<PaletteType[]>([]);
+  const colorMapHistory = useHistory<number[][]>([]);
+
+  const keymap = keymapHistory.state;
+  const setKeymap = keymapHistory.setState;
+  const palette = paletteHistory.state;
+  const setPalette = paletteHistory.setState;
+  const colorMap = colorMapHistory.state;
+  const setColorMap = colorMapHistory.setState;
   const [macros, setMacros] = useState<MacrosType[]>();
   const [superkeys, setSuperkeys] = useState<SuperkeysType[]>();
 
@@ -516,6 +525,31 @@ const LayoutEditor = (props: LayoutEditorProps) => {
   } = props;
 
   const layoutEditorContainerRef = useRef(null);
+
+  // Undo/Redo keyboard shortcuts - dispatch based on current mode
+  const handleUndo = useCallback(() => {
+    if (modeselect === "keyboard") {
+      keymapHistory.undo();
+    } else {
+      colorMapHistory.undo();
+      paletteHistory.undo();
+    }
+    setModified(true);
+    startContext();
+  }, [modeselect, keymapHistory, colorMapHistory, paletteHistory, startContext]);
+
+  const handleRedo = useCallback(() => {
+    if (modeselect === "keyboard") {
+      keymapHistory.redo();
+    } else {
+      colorMapHistory.redo();
+      paletteHistory.redo();
+    }
+    setModified(true);
+    startContext();
+  }, [modeselect, keymapHistory, colorMapHistory, paletteHistory, startContext]);
+
+  useUndoRedoKeys(handleUndo, handleRedo, !isSaving);
 
   const onLayerNameChange = (newName: string) => {
     const slicedLayerNames = layerNames.slice();
@@ -788,10 +822,10 @@ const LayoutEditor = (props: LayoutEditorProps) => {
         setScanningStep(10);
         setLedIndexStart(currentDevice?.device.info.product === "Raise" ? 80 : 80);
         setNeuronID(chipID);
-        setKeymap(KeyMap);
+        keymapHistory.reset(KeyMap);
+        paletteHistory.reset(plette);
+        colorMapHistory.reset(colormap.colorMap);
         setShowDefaults(!KeyMap.onlyCustom);
-        setPalette(plette);
-        setColorMap(colormap.colorMap);
         setMacros(parsedMacros);
         setSuperkeys(parsedSuper);
         setNeuronID(chipID);
@@ -809,7 +843,19 @@ const LayoutEditor = (props: LayoutEditorProps) => {
         onDisconnect();
       }
     },
-    [state, setLoading, AnalizeChipID, restoredOk, getColormap, handleSetRestoredOk, keymapDB, onDisconnect],
+    [
+      state,
+      setLoading,
+      AnalizeChipID,
+      restoredOk,
+      getColormap,
+      handleSetRestoredOk,
+      keymapDB,
+      onDisconnect,
+      keymapHistory,
+      paletteHistory,
+      colorMapHistory,
+    ],
   );
 
   const onKeyChange = (keyCode: number) => {
@@ -822,9 +868,8 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     }
 
     try {
-      const kmap = keymap.custom.slice();
       const l = keymap.onlyCustom ? layer : layer - keymap.default.length;
-      // log.info(kmap, l, keyIndex, keyCode, keymapDB.parse(keyCode));
+      const kmap = keymap.custom.map((layerKeys, idx) => (idx === l ? [...layerKeys] : layerKeys));
       kmap[l][keyIndex] = keymapDB.parse(keyCode);
       setModified(true);
       setKeymap({
@@ -871,7 +916,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
   const onButtonKeyboardColorChange = (cLayer: number, layer: number, ledIndex: number) => {
     const isEqualColor = onVerificationColor(selectedPaletteColor, cLayer, ledIndex);
     if (!(!modified && isEqualColor)) {
-      const colormap = colorMap.slice();
+      const colormap = colorMap.map((layerColors, idx) => (idx === cLayer ? [...layerColors] : layerColors));
       colormap[cLayer][ledIndex] = selectedPaletteColor;
       setSelectedPaletteColor(colorMap[layer][ledIndex]);
       setColorMap(colormap);
@@ -999,7 +1044,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     const { currentDevice } = state;
     const idx = keymap.onlyCustom ? currentLayer : currentLayer - keymap.default.length;
     const layerMap = { keys: currentDevice.device.keyboard, underglow: currentDevice.device.keyboardUnderglow };
-    const newColormap = colorMap.slice();
+    const newColormap = colorMap.map((layerColors, i) => (i === idx ? [...layerColors] : layerColors));
 
     log.info(newColormap[idx]);
     if (newColormap.length > 0) {
@@ -1042,7 +1087,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     const { currentDevice } = state;
     const idx = keymap.onlyCustom ? currentLayer : currentLayer - keymap.default.length;
     const layerMap = { keys: currentDevice.device.keyboard, underglow: currentDevice.device.keyboardUnderglow };
-    const newColormap = colorMap.slice();
+    const newColormap = colorMap.map((layerColors, i) => (i === idx ? [...layerColors] : layerColors));
 
     log.info(newColormap[idx]);
     if (newColormap.length > 0) {
@@ -1161,11 +1206,11 @@ const LayoutEditor = (props: LayoutEditorProps) => {
     if (currentLayer < 0 || currentLayer >= colorMap.length) return;
 
     if (!isEqualColor && currentKeyIndex >= 0) {
-      const colormap = colorMap.slice();
+      const colormap = colorMap.map((layerColors, idx) => (idx === currentLayer ? [...layerColors] : layerColors));
       colormap[currentLayer][currentLedIndex] = colorIndex;
       if (currentDevice.device.keyboard.ledsLeft.includes(currentLedIndex)) setLeftSideModified(true);
       setIsMultiSelected(true);
-      setColorMap(colorMap);
+      setColorMap(colormap);
       setSelectedPaletteColor(colorIndex);
       setModified(true);
       startContext();
@@ -1261,8 +1306,8 @@ const LayoutEditor = (props: LayoutEditorProps) => {
   };
 
   const toChangeAllKeysColor = (colorIndex: number, start: number, end: number) => {
-    const colormap = colorMap.slice();
-    colormap[currentLayer] = colormap[currentLayer].fill(colorIndex, start, end);
+    const colormap = colorMap.map((layerColors, idx) => (idx === currentLayer ? [...layerColors] : layerColors));
+    colormap[currentLayer].fill(colorIndex, start, end);
     setLeftSideModified(true);
     setColorMap(colormap);
     setModified(true);
@@ -1541,6 +1586,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
       };
       scanner();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentLanguageLayout, inContext, keymap.custom, modified, previousLayer, scanKeyboard, scanned, setLoading]);
 
   useEffect(() => {
@@ -1570,6 +1616,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
         if (key.extraLabel === "MACRO") {
           const MNumber = key.keyCode - 53852;
           if (
+            macros &&
             macros[MNumber] !== undefined &&
             macros[MNumber].name !== undefined &&
             macros[MNumber].name.substring(0, 5) !== "" &&
@@ -1584,7 +1631,7 @@ const LayoutEditor = (props: LayoutEditorProps) => {
       });
     }
 
-    if (localLayerData !== undefined && superkeys.length > 0) {
+    if (localLayerData !== undefined && superkeys && superkeys.length > 0) {
       localLayerData = localLayerData.map(key => {
         const newSKey = key;
         if (key.extraLabel === "SUPER") {
@@ -1740,6 +1787,10 @@ const LayoutEditor = (props: LayoutEditorProps) => {
           inContext={modified}
           saveButtonRef={saveButtonRef}
           discardChangesButtonRef={discardChangesButtonRef}
+          onUndo={handleUndo}
+          onRedo={handleRedo}
+          canUndo={modeselect === "keyboard" ? keymapHistory.canUndo : colorMapHistory.canUndo || paletteHistory.canUndo}
+          canRedo={modeselect === "keyboard" ? keymapHistory.canRedo : colorMapHistory.canRedo || paletteHistory.canRedo}
         />
         <div className="w-full h-[inherit] keyboardsWrapper">
           {/* <div className="raise-editor layer-col h-full"> // Set keyboard on bottom */}

--- a/src/renderer/views/MacroEditor.tsx
+++ b/src/renderer/views/MacroEditor.tsx
@@ -55,6 +55,8 @@ import TimelineEditorManager from "@Renderer/modules/Macros/TimelineEditorManage
 // Tools
 import { useDevice } from "@Renderer/DeviceContext";
 import { i18n } from "@Renderer/i18n";
+import useHistory from "@Renderer/utils/useHistory";
+import useUndoRedoKeys from "@Renderer/utils/useUndoRedoKeys";
 import Backup from "../../api/backup";
 import Keymap, { KeymapDB } from "../../api/keymap";
 
@@ -113,6 +115,7 @@ const Styles = Styled.div`
 `;
 
 function MacroEditor(props: MacroEditorProps) {
+  const { startContext } = props;
   let keymapDB = new KeymapDB();
   const bkp = new Backup();
   const [isSaving, setIsSaving] = useState(false);
@@ -146,6 +149,25 @@ function MacroEditor(props: MacroEditorProps) {
   const { state: deviceState } = useDevice();
   const timelineRef = useRef(null);
 
+  // Undo/Redo for macros
+  const macrosHistory = useHistory<MacrosType[]>([]);
+  useUndoRedoKeys(macrosHistory.undo, macrosHistory.redo, !isSaving);
+  const prevMacrosHistoryState = useRef(macrosHistory.state);
+
+  // Sync history state back to component state on undo/redo
+  useEffect(() => {
+    if (macrosHistory.state !== prevMacrosHistoryState.current && macrosHistory.state.length > 0) {
+      prevMacrosHistoryState.current = macrosHistory.state;
+      setState(prev => ({
+        ...prev,
+        macros: macrosHistory.state,
+        usedMemory: macrosHistory.state.map(m => m.actions).flat().length,
+        modified: true,
+      }));
+      startContext();
+    }
+  }, [macrosHistory.state, startContext]);
+
   const limitActions = (actions: MacroActionsType[]) => {
     if (deviceState.currentDevice.device.info.product !== "Raise") {
       return actions.slice(0, 100);
@@ -159,6 +181,7 @@ function MacroEditor(props: MacroEditorProps) {
 
     const macrosList: MacrosType[] = JSON.parse(JSON.stringify(macros));
     macrosList[selectedMacro].actions = limitActions(macrosList[selectedMacro].actions.concat(actions));
+    macrosHistory.setState(macrosList);
     state.macros = macrosList;
     state.modified = true;
     setState({ ...state });
@@ -172,6 +195,7 @@ function MacroEditor(props: MacroEditorProps) {
 
     const macrosList = JSON.parse(JSON.stringify(macros));
     macrosList[selectedMacro].actions = limitActions(JSON.parse(JSON.stringify(actions)));
+    macrosHistory.setState(macrosList);
     if (!modified) {
       state.macros = macrosList;
       state.modified = true;
@@ -188,6 +212,7 @@ function MacroEditor(props: MacroEditorProps) {
     const { macros, selectedMacro } = state;
     const localMacros = [...macros];
     localMacros[selectedMacro].name = data;
+    macrosHistory.setState(localMacros);
     state.macros = localMacros;
     state.modified = true;
     setState({ ...state });
@@ -206,6 +231,7 @@ function MacroEditor(props: MacroEditorProps) {
 
   const updateMacros = (recievedMacros: MacrosType[]) => {
     const { startContext } = props;
+    macrosHistory.setState(recievedMacros);
     state.macros = recievedMacros;
     state.modified = true;
     state.usedMemory = recievedMacros.map(m => m.actions).flat().length;
@@ -474,6 +500,7 @@ function MacroEditor(props: MacroEditorProps) {
       const parsedMacros = parseMacrosRaw(macrosRaw, state.storedMacros);
       const supersRaw = await currentDevice.command("superkeys.map");
       const parsedSuper = parseSuperkeysRaw(supersRaw, state.storedSuper);
+      macrosHistory.reset(parsedMacros);
       state.macros = parsedMacros;
       state.superkeys = parsedSuper;
       state.keymap = keymap;
@@ -739,6 +766,10 @@ function MacroEditor(props: MacroEditorProps) {
           inContext={modified}
           saveButtonRef={saveButtonRef}
           discardChangesButtonRef={discardChangesButtonRef}
+          onUndo={macrosHistory.undo}
+          onRedo={macrosHistory.redo}
+          canUndo={macrosHistory.canUndo}
+          canRedo={macrosHistory.canRedo}
         />
 
         <Callout

--- a/src/renderer/views/SuperkeysEditor.tsx
+++ b/src/renderer/views/SuperkeysEditor.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import Styled from "styled-components";
 import log from "electron-log/renderer";
@@ -51,6 +51,8 @@ import { useDevice } from "@Renderer/DeviceContext";
 import { i18n } from "@Renderer/i18n";
 import Store from "@Renderer/utils/Store";
 import getLanguage from "@Renderer/utils/language";
+import useHistory from "@Renderer/utils/useHistory";
+import useUndoRedoKeys from "@Renderer/utils/useUndoRedoKeys";
 import Keymap, { KeymapDB } from "../../api/keymap";
 import Backup from "../../api/backup";
 import { parseMacrosRaw, parseSuperkeysRaw, serializeKeymap, serializeSuperkeys } from "../../api/parsers";
@@ -91,6 +93,7 @@ const Styles = Styled.div`
 const MAX_SUPERKEYS = 70;
 
 function SuperkeysEditor(props: SuperkeysEditorProps) {
+  const { startContext } = props;
   let keymapDB = new KeymapDB();
   const bkp = new Backup();
   const [isSaving, setIsSaving] = useState(false);
@@ -122,12 +125,31 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
   const [showLimitModal, setShowLimitModal] = useState(false);
   const { state: deviceState } = useDevice();
 
+  // Undo/Redo for superkeys
+  const superkeysHistory = useHistory<SuperkeysType[]>([]);
+  useUndoRedoKeys(superkeysHistory.undo, superkeysHistory.redo, !isSaving);
+  const prevSuperkeysHistoryState = useRef(superkeysHistory.state);
+
+  // Sync history state back to component state on undo/redo
+  useEffect(() => {
+    if (superkeysHistory.state !== prevSuperkeysHistoryState.current && superkeysHistory.state.length > 0) {
+      prevSuperkeysHistoryState.current = superkeysHistory.state;
+      setState(prev => ({
+        ...prev,
+        superkeys: superkeysHistory.state,
+        modified: true,
+      }));
+      startContext();
+    }
+  }, [superkeysHistory.state, startContext]);
+
   const onKeyChange = (keyCode: number) => {
     const { superkeys, selectedSuper, selectedAction } = state;
     const { startContext } = props;
-    const newData = superkeys;
+    const newData = JSON.parse(JSON.stringify(superkeys));
     newData[selectedSuper].actions[selectedAction] = keyCode;
     log.info("keyCode: ", keyCode);
+    superkeysHistory.setState(newData);
     state.superkeys = newData;
     state.modified = true;
     setState({ ...state });
@@ -203,6 +225,7 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
       const parsedMacros = parseMacrosRaw(macrosRaw, state.storedMacros);
       const supersRaw = await currentDevice.command("superkeys.map");
       const parsedSuper = parseSuperkeysRaw(supersRaw, state.storedSuper);
+      superkeysHistory.reset(parsedSuper);
       state.modified = false;
       state.macros = parsedMacros;
       state.superkeys = parsedSuper;
@@ -248,6 +271,7 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
   const updateSuper = (newSuper: SuperkeysType[], newID: number) => {
     const { startContext } = props;
     // log.info("launched update super using data:", newSuper, newID);
+    superkeysHistory.setState(newSuper);
     state.superkeys = newSuper;
     state.selectedSuper = newID;
     state.modified = true;
@@ -259,8 +283,9 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
     const { startContext } = props;
     const { superkeys, selectedSuper } = state;
     // log.info("launched update action using data:", newAction);
-    const newData = superkeys;
+    const newData = JSON.parse(JSON.stringify(superkeys));
     newData[selectedSuper].actions[actionNumber] = newAction;
+    superkeysHistory.setState(newData);
     state.superkeys = newData;
     state.selectedAction = actionNumber;
     state.modified = true;
@@ -271,8 +296,10 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
   const saveName = (name: string) => {
     const { startContext } = props;
     const { superkeys, selectedSuper } = state;
-    superkeys[selectedSuper].name = name;
-    state.superkeys = superkeys;
+    const newSuperkeys = JSON.parse(JSON.stringify(superkeys));
+    newSuperkeys[selectedSuper].name = name;
+    superkeysHistory.setState(newSuperkeys);
+    state.superkeys = newSuperkeys;
     state.modified = true;
     setState({ ...state });
     startContext();
@@ -568,6 +595,10 @@ function SuperkeysEditor(props: SuperkeysEditorProps) {
           isSaving={isSaving}
           saveButtonRef={saveButtonRef}
           discardChangesButtonRef={discardChangesButtonRef}
+          onUndo={superkeysHistory.undo}
+          onRedo={superkeysHistory.redo}
+          canUndo={superkeysHistory.canUndo}
+          canRedo={superkeysHistory.canRedo}
         />
 
         <Callout


### PR DESCRIPTION
Implement undo/redo for Layout Editor, Macro Editor, and Superkeys Editor:


https://github.com/user-attachments/assets/50cae456-a6e9-4f3b-9a38-87225142b67c


- Add useHistory hook for state management with undo/redo support (50 entry limit)
- Add useUndoRedoKeys hook for Ctrl+Z/Y keyboard shortcuts (Cmd on macOS)
- Add undo/redo buttons to PageHeader component

Each editor maintains independent history that resets on device scan/discard.