### PR TITLE
Enhance RGB to RGBW conversion

### DIFF
--- a/src/api/color/RGBWtoRGB.test.ts
+++ b/src/api/color/RGBWtoRGB.test.ts
@@ -1,11 +1,52 @@
-import { expect, test } from "vitest";
+import { expect, test, describe } from "vitest";
 import { rgbw2b } from "./RGBWtoRGB";
 
-test.each([
-  { input: { r: 10, g: 20, b: 30, w: 40 }, expected: { r: 50, g: 60, b: 70, rgb: "rgb(50, 60, 70)" } },
-  { input: { r: 10, g: 20, b: 30, w: -40 }, expected: { r: 10, g: 20, b: 30, rgb: "rgb(10, 20, 30)" } },
-  { input: { r: 10, g: 20, b: 30, w: 1000 }, expected: { r: 255, g: 255, b: 255, rgb: "rgb(255, 255, 255)" } },
-  { input: { r: 100, g: 20, b: 30, w: 200 }, expected: { r: 255, g: 220, b: 230, rgb: "rgb(255, 220, 230)" } },
-])("rgbw2b($input) = $expected", ({ input, expected }) => {
-  expect(rgbw2b(input)).toEqual(expected);
+describe("rgbw2b", () => {
+  test("all zeros returns black", () => {
+    const result = rgbw2b({ r: 0, g: 0, b: 0, w: 0 });
+    expect(result.r).toBe(0);
+    expect(result.g).toBe(0);
+    expect(result.b).toBe(0);
+    expect(result.rgb).toBe("rgb(0, 0, 0)");
+  });
+
+  test("white channel adds to all RGB channels", () => {
+    const result = rgbw2b({ r: 10, g: 20, b: 30, w: 40 });
+    expect(result.r).toBe(50);
+    expect(result.g).toBe(60);
+    expect(result.b).toBe(70);
+    expect(result.rgb).toBe("rgb(50, 60, 70)");
+  });
+
+  test("negative white is sanitized to 0", () => {
+    const result = rgbw2b({ r: 10, g: 20, b: 30, w: -40 });
+    expect(result.r).toBe(10);
+    expect(result.g).toBe(20);
+    expect(result.b).toBe(30);
+  });
+
+  test("result clamps at 255", () => {
+    const result = rgbw2b({ r: 200, g: 200, b: 200, w: 100 });
+    expect(result.r).toBe(255);
+    expect(result.g).toBe(255);
+    expect(result.b).toBe(255);
+  });
+
+  test("pure RGB values without white pass through", () => {
+    const red = rgbw2b({ r: 255, g: 0, b: 0, w: 0 });
+    expect(red.r).toBe(255);
+    expect(red.g).toBe(0);
+    expect(red.b).toBe(0);
+
+    const green = rgbw2b({ r: 0, g: 255, b: 0, w: 0 });
+    expect(green.g).toBe(255);
+
+    const blue = rgbw2b({ r: 0, g: 0, b: 255, w: 0 });
+    expect(blue.b).toBe(255);
+  });
+
+  test("generates correct rgb string", () => {
+    const result = rgbw2b({ r: 100, g: 50, b: 25, w: 10 });
+    expect(result.rgb).toBe("rgb(110, 60, 35)");
+  });
 });

--- a/src/api/color/RGBWtoRGB.ts
+++ b/src/api/color/RGBWtoRGB.ts
@@ -2,20 +2,19 @@ import { sanitizeIntensity } from "./sanitizeIntensity";
 import { RGB, RGBW } from "./types";
 
 /**
- * Convert a RGBW color to RGB .
- * @param {RGBW} color - A RGBW color from the hardware (0-255 each channel)
- * @returns {RGB} - The color converted to RGB for UI display
+ * Convert a RGBW color to RGB
+ * @param {RGBW} color - A RGBW color from the
+ * @returns {RGB} - The color converted to RGB
  */
 export function rgbw2b(color: RGBW): RGB {
-  const rIn = sanitizeIntensity(color.r);
-  const gIn = sanitizeIntensity(color.g);
-  const bIn = sanitizeIntensity(color.b);
-  const wIn = sanitizeIntensity(color.w);
+  const sanitizedR = sanitizeIntensity(color.r);
+  const sanitizedG = sanitizeIntensity(color.g);
+  const sanitizedB = sanitizeIntensity(color.b);
+  const sanitizedW = sanitizeIntensity(color.w);
 
-  // Add white contribution back to each RGB channel
-  const r = sanitizeIntensity(rIn + wIn);
-  const g = sanitizeIntensity(gIn + wIn);
-  const b = sanitizeIntensity(bIn + wIn);
+  const r = sanitizeIntensity(sanitizedR + sanitizedW);
+  const g = sanitizeIntensity(sanitizedG + sanitizedW);
+  const b = sanitizeIntensity(sanitizedB + sanitizedW);
 
   return { r, g, b, rgb: `rgb(${r}, ${g}, ${b})` };
 }

--- a/src/api/color/RGBWtoRGB.ts
+++ b/src/api/color/RGBWtoRGB.ts
@@ -2,19 +2,20 @@ import { sanitizeIntensity } from "./sanitizeIntensity";
 import { RGB, RGBW } from "./types";
 
 /**
- * Convert a RGBW color to RGB
- * @param {RGBW} color - A RGBW color
- * @returns {RGB} - The color converted to RGB
+ * Convert a RGBW color to RGB .
+ * @param {RGBW} color - A RGBW color from the hardware (0-255 each channel)
+ * @returns {RGB} - The color converted to RGB for UI display
  */
 export function rgbw2b(color: RGBW): RGB {
-  const sanitizedR = sanitizeIntensity(color.r);
-  const sanitizedG = sanitizeIntensity(color.g);
-  const sanitizedB = sanitizeIntensity(color.b);
-  const sanitizedW = sanitizeIntensity(color.w);
+  const rIn = sanitizeIntensity(color.r);
+  const gIn = sanitizeIntensity(color.g);
+  const bIn = sanitizeIntensity(color.b);
+  const wIn = sanitizeIntensity(color.w);
 
-  const r = sanitizeIntensity(sanitizedW + sanitizedR);
-  const g = sanitizeIntensity(sanitizedW + sanitizedG);
-  const b = sanitizeIntensity(sanitizedW + sanitizedB);
+  // Add white contribution back to each RGB channel
+  const r = sanitizeIntensity(rIn + wIn);
+  const g = sanitizeIntensity(gIn + wIn);
+  const b = sanitizeIntensity(bIn + wIn);
 
   return { r, g, b, rgb: `rgb(${r}, ${g}, ${b})` };
 }

--- a/src/api/color/RGBWtoRGB.ts
+++ b/src/api/color/RGBWtoRGB.ts
@@ -3,7 +3,7 @@ import { RGB, RGBW } from "./types";
 
 /**
  * Convert a RGBW color to RGB
- * @param {RGBW} color - A RGBW color from the
+ * @param {RGBW} color - A RGBW color
  * @returns {RGB} - The color converted to RGB
  */
 export function rgbw2b(color: RGBW): RGB {

--- a/src/api/color/RGBtoRGBW.test.ts
+++ b/src/api/color/RGBtoRGBW.test.ts
@@ -1,10 +1,120 @@
-import { expect, test } from "vitest";
+import { expect, test, describe } from "vitest";
 import { rgb2w } from "./RGBtoRGBW";
 
-test.each([
-  { input: { r: 0, g: 0, b: 0 }, expected: { r: 0, g: 0, b: 0, w: 0 } },
-  { input: { r: 100, g: 200, b: 250 }, expected: { r: 0, g: 100, b: 150, w: 100 } },
-  { input: { r: -100, g: 100, b: 200 }, expected: { r: 0, g: 100, b: 200, w: 0 } },
-])("rgb2w($input) = $expected", ({ input, expected }) => {
-  expect(rgb2w(input)).toEqual(expected);
+describe("rgb2w", () => {
+  test("pure black returns all zeros", () => {
+    expect(rgb2w({ r: 0, g: 0, b: 0 })).toEqual({ r: 0, g: 0, b: 0, w: 0 });
+  });
+
+  test("pure white uses mostly white LED for clean white", () => {
+    const result = rgb2w({ r: 255, g: 255, b: 255 });
+
+    // Should use mostly white LED (>90%)
+    expect(result.w).toBeGreaterThan(230);
+
+    // RGB should be minimal
+    expect(result.r).toBeLessThan(25);
+    expect(result.g).toBeLessThan(25);
+    expect(result.b).toBeLessThan(25);
+
+    // All RGB channels equal for white
+    expect(result.r).toBe(result.g);
+    expect(result.g).toBe(result.b);
+  });
+
+  test("gray uses mostly white LED", () => {
+    const gray128 = rgb2w({ r: 128, g: 128, b: 128 });
+
+    // Gray should use mostly white LED
+    expect(gray128.w).toBeGreaterThan(100);
+
+    // RGB should be minimal
+    expect(gray128.r).toBeLessThan(20);
+
+    // All RGB channels equal for gray
+    expect(gray128.r).toBe(gray128.g);
+    expect(gray128.g).toBe(gray128.b);
+  });
+
+  test("saturated colors have zero white", () => {
+    // Pure red - fully saturated, should have no white (min=0)
+    const pureRed = rgb2w({ r: 255, g: 0, b: 0 });
+    expect(pureRed.w).toBe(0);
+    expect(pureRed.r).toBe(255);
+    expect(pureRed.g).toBe(0);
+    expect(pureRed.b).toBe(0);
+
+    // Pure green
+    const pureGreen = rgb2w({ r: 0, g: 255, b: 0 });
+    expect(pureGreen.w).toBe(0);
+    expect(pureGreen.g).toBe(255);
+
+    // Pure blue
+    const pureBlue = rgb2w({ r: 0, g: 0, b: 255 });
+    expect(pureBlue.w).toBe(0);
+    expect(pureBlue.b).toBe(255);
+
+    // BA00FF - saturated purple, should have no white (min=0)
+    const purple = rgb2w({ r: 186, g: 0, b: 255 });
+    expect(purple.w).toBe(0);
+    expect(purple.r).toBe(186);
+    expect(purple.g).toBe(0);
+    expect(purple.b).toBe(255);
+  });
+
+  test("mint green preserves color with moderate white", () => {
+    // #99FFCC = rgb(153, 255, 204) - a mint green (40% saturation)
+    const mint = rgb2w({ r: 153, g: 255, b: 204 });
+
+    // Should have moderate white
+    expect(mint.w).toBeGreaterThan(50);
+    expect(mint.w).toBeLessThan(120);
+
+    // Green should remain dominant
+    expect(mint.g).toBeGreaterThan(mint.r);
+    expect(mint.g).toBeGreaterThan(mint.b);
+
+    // Roundtrip should work: r + w = original r
+    expect(mint.r + mint.w).toBe(153);
+  });
+
+  test("orange and red remain distinguishable", () => {
+    const red = rgb2w({ r: 255, g: 0, b: 0 });
+    const orange = rgb2w({ r: 255, g: 128, b: 0 });
+    const deepRed = rgb2w({ r: 180, g: 0, b: 0 });
+
+    // All saturated, no white
+    expect(red.w).toBe(0);
+    expect(orange.w).toBe(0);
+    expect(deepRed.w).toBe(0);
+
+    // Orange has green component
+    expect(orange.g).toBe(128);
+    expect(red.g).toBe(0);
+  });
+
+  test("light pink has some white but keeps pink tint", () => {
+    const lightPink = rgb2w({ r: 255, g: 204, b: 204 });
+    // Should have moderate white
+    expect(lightPink.w).toBeGreaterThan(80);
+    // Red should be higher than green/blue
+    expect(lightPink.r).toBeGreaterThan(lightPink.g);
+    expect(lightPink.g).toBe(lightPink.b);
+  });
+
+  test("negative input values are sanitized to 0", () => {
+    const result = rgb2w({ r: -100, g: 100, b: 200 });
+    expect(result.r).toBeGreaterThanOrEqual(0);
+    expect(result.g).toBeGreaterThanOrEqual(0);
+    expect(result.b).toBeGreaterThanOrEqual(0);
+    expect(result.w).toBeGreaterThanOrEqual(0);
+  });
+
+  test("values over 255 are sanitized", () => {
+    const result = rgb2w({ r: 300, g: 300, b: 300 });
+    expect(result.r).toBeLessThanOrEqual(255);
+    expect(result.g).toBeLessThanOrEqual(255);
+    expect(result.b).toBeLessThanOrEqual(255);
+    expect(result.w).toBeLessThanOrEqual(255);
+  });
 });

--- a/src/api/color/RGBtoRGBW.ts
+++ b/src/api/color/RGBtoRGBW.ts
@@ -2,21 +2,66 @@ import { sanitizeIntensity } from "./sanitizeIntensity";
 import { RGB, RGBW } from "./types";
 
 /**
- * Convert a RGB color to RGBW
- * @param {RGB} color - A RGB color
- * @returns {RGBW} - The color converted to RGBW
+ * Base extraction factor - how much of the gray component goes to white LED.
+ * This is scaled based on saturation.
+ */
+const BASE_WHITE_EXTRACTION = 0.5;
+
+/**
+ * For low-saturation colors (white, gray), we extract to the white LED.
+ * This ensures pure white uses the white LED for clean, efficient white light.
+ * Value of 1.0 means 100% extraction for maximum brightness and efficiency.
+ * Examples:
+ * - Pure white (#FFFFFF) will be translated to RGBW(0, 0, 0, 255)
+ * - Gray 50% (#808080) will be translated to RGBW(0, 0, 0, 128)
+ */
+const WHITE_EXTRACTION_FOR_GRAYS = 1.0;
+
+/**
+ * Saturation threshold below which we treat the color as "gray/white"
+ * and use higher white extraction.
+ */
+const GRAY_SATURATION_THRESHOLD = 0.15;
+
+/**
+ * Convert an RGB color to RGBW.
+ *
+ * This algorithm extracts a portion of the common "gray" component
+ * to the white LED. For gray/white colors, it uses mostly the white LED
+ * to ensure clean white. For saturated colors, it preserves more color
+ * in the RGB channels.
+ *
+ * @param {RGB} color - A RGB color in sRGB space (0-255)
+ * @returns {RGBW} - The color converted to RGBW for LED hardware
  */
 export function rgb2w(color: RGB): RGBW {
-  const sanitizedR = sanitizeIntensity(color.r);
-  const sanitizedG = sanitizeIntensity(color.g);
-  const sanitizedB = sanitizeIntensity(color.b);
+  const r = sanitizeIntensity(color.r);
+  const g = sanitizeIntensity(color.g);
+  const b = sanitizeIntensity(color.b);
+  const minVal = Math.min(r, g, b);
+  const maxVal = Math.max(r, g, b);
 
-  const minVal = Math.min(sanitizedR, Math.min(sanitizedG, sanitizedB));
+  const saturation = maxVal > 0 ? (maxVal - minVal) / maxVal : 0;
 
+  // Determine white extraction factor based on saturation:
+  // - Low saturation (gray/white): use high extraction (mostly white LED)
+  // - High saturation (colors): use lower extraction (preserve RGB color)
+  let extractionFactor: number;
+  if (saturation <= GRAY_SATURATION_THRESHOLD) {
+    // Gray/white colors - use mostly white LED for clean appearance
+    extractionFactor = WHITE_EXTRACTION_FOR_GRAYS;
+  } else {
+    // Colored light - scale extraction based on saturation
+    // More saturated = less white extraction
+    const saturationScale = 1 - (saturation - GRAY_SATURATION_THRESHOLD) / (1 - GRAY_SATURATION_THRESHOLD);
+    extractionFactor = BASE_WHITE_EXTRACTION + (WHITE_EXTRACTION_FOR_GRAYS - BASE_WHITE_EXTRACTION) * saturationScale * 0.3;
+  }
+
+  const w = Math.round(minVal * extractionFactor);
   return {
-    r: sanitizedR - minVal,
-    b: sanitizedB - minVal,
-    g: sanitizedG - minVal,
-    w: minVal,
+    r: r - w,
+    g: g - w,
+    b: b - w,
+    w: w,
   };
 }

--- a/src/api/color/RGBtoRGBW.ts
+++ b/src/api/color/RGBtoRGBW.ts
@@ -2,8 +2,7 @@ import { sanitizeIntensity } from "./sanitizeIntensity";
 import { RGB, RGBW } from "./types";
 
 /**
- * Base extraction factor - how much of the gray component goes to white LED.
- * This is scaled based on saturation.
+ * Base extraction factor - how much of the gray component goes to white LED. Scaled based on saturation.
  */
 const BASE_WHITE_EXTRACTION = 0.5;
 
@@ -12,14 +11,13 @@ const BASE_WHITE_EXTRACTION = 0.5;
  * This ensures pure white uses the white LED for clean, efficient white light.
  * Value of 1.0 means 100% extraction for maximum brightness and efficiency.
  * Examples:
- * - Pure white (#FFFFFF) will be translated to RGBW(0, 0, 0, 255)
- * - Gray 50% (#808080) will be translated to RGBW(0, 0, 0, 128)
+ * - Pure white (#FFFFFF) with 1.0 factor will be translated to RGBW(0, 0, 0, 255)
+ * - Pure white (#FFFFFF) with 0.95 factor will be translated to RGBW(13, 13, 13, 242)
  */
-const WHITE_EXTRACTION_FOR_GRAYS = 1.0;
+const WHITE_EXTRACTION_FOR_GRAYS = 0.95;
 
 /**
- * Saturation threshold below which we treat the color as "gray/white"
- * and use higher white extraction.
+ * Saturation threshold below which we treat the color as "gray/white" and use higher white extraction.
  */
 const GRAY_SATURATION_THRESHOLD = 0.15;
 
@@ -31,37 +29,35 @@ const GRAY_SATURATION_THRESHOLD = 0.15;
  * to ensure clean white. For saturated colors, it preserves more color
  * in the RGB channels.
  *
- * @param {RGB} color - A RGB color in sRGB space (0-255)
- * @returns {RGBW} - The color converted to RGBW for LED hardware
+ * @param {RGB} color - A RGB color
+ * @returns {RGBW} - The color converted to RGBW
  */
 export function rgb2w(color: RGB): RGBW {
-  const r = sanitizeIntensity(color.r);
-  const g = sanitizeIntensity(color.g);
-  const b = sanitizeIntensity(color.b);
-  const minVal = Math.min(r, g, b);
-  const maxVal = Math.max(r, g, b);
+  const sanitizedR = sanitizeIntensity(color.r);
+  const sanitizedG = sanitizeIntensity(color.g);
+  const sanitizedB = sanitizeIntensity(color.b);
+  const minVal = Math.min(sanitizedR, sanitizedG, sanitizedB);
+  const maxVal = Math.max(sanitizedR, sanitizedG, sanitizedB);
 
   const saturation = maxVal > 0 ? (maxVal - minVal) / maxVal : 0;
 
-  // Determine white extraction factor based on saturation:
+  // Determine a white extraction factor based on saturation:
   // - Low saturation (gray/white): use high extraction (mostly white LED)
   // - High saturation (colors): use lower extraction (preserve RGB color)
   let extractionFactor: number;
   if (saturation <= GRAY_SATURATION_THRESHOLD) {
-    // Gray/white colors - use mostly white LED for clean appearance
     extractionFactor = WHITE_EXTRACTION_FOR_GRAYS;
   } else {
-    // Colored light - scale extraction based on saturation
-    // More saturated = less white extraction
     const saturationScale = 1 - (saturation - GRAY_SATURATION_THRESHOLD) / (1 - GRAY_SATURATION_THRESHOLD);
     extractionFactor = BASE_WHITE_EXTRACTION + (WHITE_EXTRACTION_FOR_GRAYS - BASE_WHITE_EXTRACTION) * saturationScale * 0.3;
   }
 
   const w = Math.round(minVal * extractionFactor);
+
   return {
-    r: r - w,
-    g: g - w,
-    b: b - w,
+    r: sanitizedR - w,
+    g: sanitizedG - w,
+    b: sanitizedB - w,
     w: w,
   };
 }


### PR DESCRIPTION
## Description
Improves the RGB → RGBW conversion to fix washed-out and “dirty” colors on RGBW lights.  
The new approach uses **saturation-aware white extraction**, preserving color vibrancy while keeping whites clean and efficient.

### Technical Root Cause
The old algorithm used: `W = min(R, G, B)`
This pushed shared RGB values into the white LED, which:
- Over-extracted white
- Ignored color saturation
- Washed out pastels and light colors


## Solution
Introduce a **saturation-based white extraction**:
- Whites / grays → use the white LED
- Saturated colors → stay RGB-only
- Pastels → smoothly blend RGB + W

### Algorithm Logic
1. Compute saturation: `saturation = (max - min) / max`
2. Extract white based on saturation:
- ≤ 15% → 100% white
- 100% → 0% white
- In between → smooth interpolation
3. Subtract extracted white from RGB

## Visual Examples

| Color | Input | Old RGBW | New RGBW | Result |
|------|------|---------|---------|--------|
| White | (255,255,255) | (0,0,0,255) | **(0,0,0,255)** | Same |
| Purple | (186,0,255) | (186,0,255,0) | **(186,0,255,0)** | Same |
| Mint | (153,255,204) | (0,102,51,153) ❌ | **(60,162,111,93)** | ✅ Vibrant |
| Light Pink | (255,204,204) | (51,0,0,204) ❌ | **(124,73,73,131)** | ✅ Correct tint |

## Wireless Setup Power Impact
- **White / gray** → no change
- **Saturated colors** → no change
- **Pastels** → ~10–15% higher LED usage

Example (Mint Green):
- Old: RGBW(0,102,51,153) → 306 units
- New: RGBW(60,162,111,93) → 426 units  
→ More power, but correct color instead of grayish output

**Battery Life Consideration:**
Not sure what percentage of the power consumptions of Digma keyboards are from light, but my guess is that it should increase power usage more than 5-7% overall in the worst case, when all colors are pastel. Using whitish or saturated colors should remain consumption on the previous level.

## Tunable Parameters - Balancing Color Accuracy vs Power Efficiency
The algorithm can be tuned for different priorities by adjusting three constants in `RGBtoRGBW.ts`:
```
const BASE_WHITE_EXTRACTION = 0.5;           // For mid-saturated colors
const WHITE_EXTRACTION_FOR_GRAYS = 1.0;      // For white/gray colors
const GRAY_SATURATION_THRESHOLD = 0.15;      // Saturation cutoff for "gray"### Parameter Guide
```

#### `WHITE_EXTRACTION_FOR_GRAYS` (Currently: 0.95)
Controls white LED usage for low-saturation colors (white, gray, near-white).

**Example - Pure White (255, 255, 255):**
- 1.0 → RGBW(0, 0, 0, 255) - pure white LED
- 0.95 → RGBW(13, 13, 13, 242) - white LED + 5% RGB correction
- 0.8 → RGBW(51, 51, 51, 204) - white LED + 20% RGB correction

#### `BASE_WHITE_EXTRACTION` (Currently: 0.5)
Controls white LED usage for moderately saturated colors (pastels, tinted colors).

| Value | Effect | Color Accuracy | Power Efficiency | Use Case |
|-------|--------|----------------|------------------|----------|
| **0.3-0.4** | Low extraction | **Best accuracy** | Lower efficiency | Maximize color vibrancy |
| **0.5** | Medium extraction | **Balanced** | Balanced | **Recommended** - Good balance |
| **0.6-0.7** | High extraction | Slight color wash | **Better efficiency** | Prioritize battery life |

**Example - Mint Green (153, 255, 204):**
- 0.3 → RGBW(107, 209, 158, 46) - more vibrant, more power
- 0.5 → RGBW(60, 162, 111, 93) - balanced (current)
- 0.7 → RGBW(25, 127, 76, 128) - less vibrant, less power

#### `GRAY_SATURATION_THRESHOLD` (Currently: 0.15)
Defines the saturation boundary between "gray" (high white extraction) and "colored" (lower white extraction).

| Value | Effect | Color Accuracy | Power Efficiency | Use Case |
|-------|--------|----------------|------------------|----------|
| **0.10** | Narrower gray range | More colors keep RGB | Lower efficiency | Preserve even slightly tinted colors |
| **0.15** | Medium gray range | **Balanced** | Balanced | **Recommended** |
| **0.20-0.25** | Wider gray range | Desaturated pastels | **Better efficiency** | Treat more colors as "gray" |

**What is saturation?** `saturation = (max - min) / max`
- 0.0 = Pure gray/white
- 0.15 = Slightly tinted (like off-white)
- 0.5 = Moderately colorful (pastels)
- 1.0 = Fully saturated (pure colors)

### Preset Configurations

**Maximum Color Accuracy (Current suggestion):** - Best visual quality, moderate power consumption.
```
const BASE_WHITE_EXTRACTION = 0.5;
const WHITE_EXTRACTION_FOR_GRAYS = 0.95;
const GRAY_SATURATION_THRESHOLD = 0.15;
```

**Balanced Mode:** - Slightly better power efficiency, minimal quality loss.
```
const BASE_WHITE_EXTRACTION = 0.6;
const WHITE_EXTRACTION_FOR_GRAYS = 1.0;
const GRAY_SATURATION_THRESHOLD = 0.18;
```

**Power Save Mode:** - Best battery life, some color vibrancy loss on pastels.
```
const BASE_WHITE_EXTRACTION = 0.7;
const WHITE_EXTRACTION_FOR_GRAYS = 1.0;
const GRAY_SATURATION_THRESHOLD = 0.25;
```

**Maximum Vibrancy Mode:** - Most vibrant pastels, higher power consumption.
```
const BASE_WHITE_EXTRACTION = 0.4;
const WHITE_EXTRACTION_FOR_GRAYS = 1.0;
const GRAY_SATURATION_THRESHOLD = 0.12;
```

### When to Adjust

- **White looks tinted/dirty** → Reduce `WHITE_EXTRACTION_FOR_GRAYS`
- **Pastels look washed out** → Reduce `BASE_WHITE_EXTRACTION`
- **Battery life critical** → Increase both to 0.7 and threshold to 0.2
- **Extremely vibrant needed** → Reduce both to 0.3-0.4 and threshold to 0.1