### PR TITLE
feat: Mandatory files required for flatpak building on flathub

### DIFF
--- a/build/com.dygma.bazecor.desktop
+++ b/build/com.dygma.bazecor.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.5
+Type=Application
+Name=Bazecor
+Comment=Configurator for Dygma Raise and Defy keyboards.
+Exec=Bazecor %U
+Icon=com.dygma.bazecor
+Categories=Utility;
+Terminal=false
+Keywords=keyboard;configuration;firmware;dygma;raise;defy;keymap;layout;macro;ergonomic;customization;

--- a/build/com.dygma.bazecor.metainfo.xml
+++ b/build/com.dygma.bazecor.metainfo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.dygma.bazecor</id>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <content_rating type="oars-1.1"></content_rating>
+  <developer id="com.dygma">
+    <name>Dygma Lab S.L.</name>
+  </developer>
+  <launchable type="desktop-id">com.dygma.bazecor.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_group>Dygma</project_group>
+  <project_license>GPL-3.0-only</project_license>
+  <requires>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <display_length compare="ge">768</display_length>
+  </requires>
+  <update_contact>contact@dygma.com</update_contact>
+  <url type="bugtracker">https://github.com/Dygmalab/Bazecor/issues</url>
+  <url type="contact">https://dygma.com/pages/contact-us</url>
+  <url type="contribute">https://github.com/Dygmalab/Bazecor?tab=contributing-ov-file</url>
+  <url type="homepage">https://dygma.com/</url>
+  <url type="vcs-browser">https://github.com/Dygmalab/Bazecor</url>
+  <name>Bazecor</name>
+  <summary>Configurator for Dygma Raise and Defy keyboards</summary>
+  <description>
+    <p>Bazecor is the graphical configurator for the Dygma Raise and Defy keyboards. While still heavily under development, it&#39;s at a stage where it is already usable.</p>
+    <p>The primary purpose of the application is to allow one to configure their keyboard without having to compile or flash firmware, by storing the configuration on the keyboard itself, in EEPROM. There are no external tools required, just Bazecor itself.</p>
+    <p>Features:</p>
+    <ul>
+      <li>
+        <em>Layout Editor:</em> Edit keymaps on-the-fly, copy layers, and set defaults.
+      </li>
+      <li>
+        <em>Macro Editor:</em> Create, manage, and backup macros.
+      </li>
+      <li>
+        <em>Colormap Editor:</em> Customize per-key and underglow LED lighting.
+      </li>
+      <li>
+        <em>Firmware Upgrade:</em> Update keyboard firmware directly from the app.
+      </li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://raw.githubusercontent.com/Dygmalab/Bazecor/refs/heads/development/data/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.9.0" date="2026-06-22">
+      <url type="details">https://github.com/Dygmalab/Bazecor/releases/tag/v1.9.0</url>
+    </release>
+  </releases>
+  <keywords>
+    <keyword>keyboard</keyword>
+    <keyword>configuration</keyword>
+    <keyword>firmware</keyword>
+    <keyword>dygma</keyword>
+    <keyword>raise</keyword>
+    <keyword>defy</keyword>
+    <keyword>keymap</keyword>
+    <keyword>layout</keyword>
+    <keyword>macro</keyword>
+    <keyword>ergonomic</keyword>
+    <keyword>customization</keyword>
+  </keywords>
+</component>


### PR DESCRIPTION
This PR is simply splitting up the massive https://github.com/Dygmalab/Bazecor/pull/1123 PR I created earlier this month.

The content of this PR is the absolute minimum that we need for deploying Bazecor on Flathub app store and requires *no code change* in Bazecor.

Without https://github.com/Dygmalab/Bazecor/pull/1123, the app's udev rule file detection will be broken and the dialog box to prompt the user to install the udev rule wil appear regardless if `/etc/udev/rules.d/60-dygma.rules` is present and up-to-date. 

As a temporary work-around, I will be applying a small **temporary** patch file stored in the (future) https://github.com/flathub/com.dygma.bazecor repo, and will be applied during flathub's flatpak-builder automated launch to disable the udev rule file scanning feature entirely. 
```patch
diff --git a/src/main/setup/onReadyToShow.ts b/src/main/setup/onReadyToShow.ts
index 17273833..9e5fb174 100644
--- a/src/main/setup/onReadyToShow.ts
+++ b/src/main/setup/onReadyToShow.ts
@@ -6,11 +6,6 @@ const onReadyToShow = () => {
   const window = Window.getWindow();
   window.once("ready-to-show", () => {
     window.show();
-    if (process.platform === "linux") {
-      if (!checkUdev()) {
-        installUdev(window);
-      }
-    }
     autoUpdateOptIn(window);
   });
 };
```
This way, we will be able to get the app onto flathub, and have more time to resolve the udev rule detection mechanism, which may need to change if flathub makes the decision not to grant us access to `--filesystem=host-etc` because it is often deemed as a security risk. There are sensitive files such as `/etc/shadow` which contains the (encrypted) user login passwords.  They might recommend us to check if we have the required access to devices that matches our VendorID instead, and display the popup only then. 

Until we know what direction we must take, we can at least get the flatpak bundle going on github.

> [!WARNING]
> The first thing that is critical to understand: I could not use `com.dygmalab.bazecor` as the flatpak app-id because the appstream validator checks if https://dygmalab.com exists, and will fail, preventing us from releasing the app onto flathub. That's why we absolutely have to use `com.dygma.bazecor` since https://dygma.com exists. An alternative would be to buy the https://dygmalab.com domain, and if that's what you'd like to do, let me know and I'll change the app-id back to `com.dygmalab.bazecor`.

In this PR, there are 2 files:

1. `build/com.dygma.bazecor.desktop`
    It is specific to Flatpak, and bundled inside of the flatpak bundle. You will notice that it has `Icon=com.dygma.bazecor`, where this icon filename is mandatory and the appstream validator will fail if the icon name doesn't match the app-id name.

2. `build/com.dygma.bazecor.metainfo.xml`
    This file is known as the appstream config file. I tried my best to fill it to the best of my knowledge with the correct values. Flathub's flatkap-builder will run this command on it:
    ```sh
    appstreamcli validate com.dygma.bazecor.metainfo.xml
    ```
    If it fails, the app submission will be rejected. Also, this appstream file will be used to auto-generate the html code for the (future) http://flathub.org/en/apps/com.dygma.bazecor page once it is published. This also includes app store apps such as KDE discover, Gnome Software, etc.  Dygma devs will need to keep this file up-to-date every time a new release is made. For example:
    ```xml
    <releases>
  
      <!-- Future release (example) -->
      <release version="1.9.2" date="2026-10-22">
        <url type="details">https://github.com/Dygmalab/Bazecor/releases/tag/v1.9.2</url>
      </release>

      <!-- Future release (example) -->
      <release version="1.9.1" date="2026-08-22">
        <url type="details">https://github.com/Dygmalab/Bazecor/releases/tag/v1.9.1</url>
      </release>
    
      <!-- current release -->
      <release version="1.9.0" date="2026-06-22">
        <url type="details">https://github.com/Dygmalab/Bazecor/releases/tag/v1.9.0</url>
      </release>
  
    </releases>
    ```
    It might be possible to automate this with github actions, that's entirely up to you.
    
    
    
There is also a requirement to provide at least one `com.dygma.bazecor.png` (at least 512x512)  or `com.dygma.bazecor.svg`, but I didn't need to add such file because the existing https://github.com/Dygmalab/Bazecor/blob/development/build/logo.png meets that requirements, and I just instructed the flatpak-builder manifest file to rename it accordingly:

```yaml
- install -Dm644 build/com.dygma.bazecor.desktop "${FLATPAK_DEST}/share/applications/com.dygma.bazecor.desktop"
- install -Dm644 build/com.dygma.bazecor.metainfo.xml "${FLATPAK_DEST}/share/metainfo/com.dygma.bazecor.metainfo.xml"
- install -Dm644 build/logo.png "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.dygma.bazecor.png"
```