### PR TITLE
Add Caps Lock indicator LED setting

### DIFF
--- a/src/renderer/modules/Settings/LEDSettings.tsx
+++ b/src/renderer/modules/Settings/LEDSettings.tsx
@@ -32,6 +32,24 @@ import Callout from "@Renderer/components/molecules/Callout/Callout";
 import { i18n } from "@Renderer/i18n";
 import Heading from "@Renderer/components/atoms/Heading";
 
+const componentToHex = (component: number) =>
+  Math.max(0, Math.min(255, Math.round(component)))
+    .toString(16)
+    .padStart(2, "0");
+
+const rgbToHex = (color: { r: number; g: number; b: number }) =>
+  `#${componentToHex(color.r)}${componentToHex(color.g)}${componentToHex(color.b)}`;
+
+const hexToRgb = (hex: string) => {
+  const normalized = hex.replace("#", "");
+
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+  };
+};
+
 function LEDSettings(props: LEDSettingsPreferences) {
   const { kbData, wireless, setKbData, setWireless, connected, isWireless, hasUnderglow = true } = props;
   const [localKBData, setLocalKBData] = useState(kbData);
@@ -93,6 +111,26 @@ function LEDSettings(props: LEDSettingsPreferences) {
     setWireless({ ...localWireless, fade: checked ? 1 : 0 });
   };
 
+  const setCapsLockIndicatorEnabled = (checked: boolean) => {
+    const nextKBData = {
+      ...localKBData,
+      capsLockIndicatorEnabled: checked,
+    };
+
+    setLocalKBData(nextKBData);
+    setKbData(nextKBData);
+  };
+
+  const setCapsLockIndicatorColor = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextKBData = {
+      ...localKBData,
+      capsLockIndicatorColor: hexToRgb(event.target.value),
+    };
+
+    setLocalKBData(nextKBData);
+    setKbData(nextKBData);
+  };
+
   useEffect(() => {
     const { kbData: newKBData, wireless: newWireless } = props;
     log.log("checking for changes", newKBData, newWireless);
@@ -101,7 +139,14 @@ function LEDSettings(props: LEDSettingsPreferences) {
     setLocalWireless(newWireless);
   }, [props]);
 
-  const { ledBrightness, ledBrightnessUG, ledIdleTimeLimit } = localKBData;
+  const {
+    ledBrightness,
+    ledBrightnessUG,
+    ledIdleTimeLimit,
+    capsLockIndicatorSupported,
+    capsLockIndicatorEnabled,
+    capsLockIndicatorColor,
+  } = localKBData;
   const { idleleds, brightness, brightnessUG, fade } = localWireless;
 
   if (connected) {
@@ -212,6 +257,49 @@ function LEDSettings(props: LEDSettingsPreferences) {
             )}
           </CardContent>
         </Card>
+        {capsLockIndicatorSupported && (
+          <Card className="mt-3 max-w-2xl mx-auto" variant="default">
+            <CardHeader>
+              <CardTitle className="flex flex-row items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <IconFlashlight /> Caps Lock indicator
+                </div>
+                {isWireless && (
+                  <Badge variant="subtle" size="xs">
+                    {i18n.wireless.energyManagement.settings.lowBatteryImpact}
+                  </Badge>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-row gap-3 justify-between items-center">
+              <div className="flex flex-col">
+                <Heading headingLevel={2} renderAs="paragraph-sm" className="tracking-normal">
+                  Highlight Caps Lock when active
+                </Heading>
+                <p className="text-sm font-normal text-gray-300 dark:text-gray-100">
+                  Change the Caps Lock key color while the host reports Caps Lock as enabled.
+                </p>
+              </div>
+              <div className="flex flex-row items-center gap-3">
+                <input
+                  aria-label="Caps Lock indicator color"
+                  type="color"
+                  className="h-8 w-10 cursor-pointer rounded border border-gray-100 bg-transparent p-0 dark:border-gray-600"
+                  value={rgbToHex(capsLockIndicatorColor)}
+                  onChange={setCapsLockIndicatorColor}
+                  disabled={!capsLockIndicatorEnabled}
+                />
+                <Switch
+                  id="CapsLockIndicatorSwitch"
+                  checked={capsLockIndicatorEnabled}
+                  onCheckedChange={setCapsLockIndicatorEnabled}
+                  variant="default"
+                  size="sm"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
         <Card className="mt-3 max-w-2xl mx-auto" variant="default">
           <CardHeader>
             <CardTitle className="flex flex-row items-center justify-between">

--- a/src/renderer/types/preferences.ts
+++ b/src/renderer/types/preferences.ts
@@ -59,6 +59,13 @@ export interface KBDataPref {
   mouseWheelDelay: number;
   mouseSpeedLimit: number;
   showDefaults: boolean;
+  capsLockIndicatorSupported: boolean;
+  capsLockIndicatorEnabled: boolean;
+  capsLockIndicatorColor: {
+    r: number;
+    g: number;
+    b: number;
+  };
 }
 
 export interface PrefState {

--- a/src/renderer/views/Preferences.tsx
+++ b/src/renderer/views/Preferences.tsx
@@ -48,9 +48,7 @@ import {
   IconKeyboard,
   IconLogoDygma,
   IconSignal,
-  IconNeuronManager,
   IconChip,
-  IconWrench,
 } from "@Renderer/components/atoms/icons";
 
 import Store from "@Renderer/utils/Store";
@@ -65,11 +63,7 @@ import { delay } from "../../api/flash/delay";
 
 const store = Store.getStore();
 const sk20Raw = store.get("capabilities.sk20");
-const sk20 =
-  sk20Raw === true ||
-  sk20Raw === "true" ||
-  sk20Raw === 1 ||
-  sk20Raw === "1";
+const sk20 = sk20Raw === true || sk20Raw === "true" || sk20Raw === 1 || sk20Raw === "1";
 
 const initialWireless = {
   battery: {
@@ -131,6 +125,13 @@ const initialKBData = {
   mouseWheelDelay: 100,
   mouseSpeedLimit: 1,
   showDefaults: false,
+  capsLockIndicatorSupported: false,
+  capsLockIndicatorEnabled: false,
+  capsLockIndicatorColor: {
+    r: 255,
+    g: 80,
+    b: 0,
+  },
 };
 
 const initialPreferences = {
@@ -174,7 +175,17 @@ const Preferences = (props: PreferencesProps) => {
 
   const getNeuronData = useCallback(async () => {
     let localNeuronID = "";
-    const newKbData: KBDataPref = initialKBData;
+    const newKbData: KBDataPref = {
+      ...initialKBData,
+      keymap: {
+        ...initialKBData.keymap,
+        custom: [],
+        default: [],
+      },
+      capsLockIndicatorColor: {
+        ...initialKBData.capsLockIndicatorColor,
+      },
+    };
 
     if (state.currentDevice) {
       await state.currentDevice.command("hardware.chip_id").then((neuronID: string) => {
@@ -203,6 +214,33 @@ const Preferences = (props: PreferencesProps) => {
       await state.currentDevice.command("idleleds.time_limit").then((limit: string) => {
         newKbData.ledIdleTimeLimit = limit ? parseInt(limit, 10) : -1;
       });
+
+      const cachedHelp = state.currentDevice.commands?.help;
+      const supportedCommands = Array.isArray(cachedHelp)
+        ? (cachedHelp as string[])
+        : (((await state.currentDevice.command("help")) as string | undefined) ?? "")
+            .split(/\r?\n/)
+            .filter(command => command.length > 0);
+      newKbData.capsLockIndicatorSupported =
+        supportedCommands.includes("led.capsLockIndicator.enabled") && supportedCommands.includes("led.capsLockIndicator.color");
+
+      if (newKbData.capsLockIndicatorSupported) {
+        await state.currentDevice.command("led.capsLockIndicator.enabled").then((enabled: string) => {
+          newKbData.capsLockIndicatorEnabled = enabled ? parseInt(enabled, 10) > 0 : false;
+        });
+
+        await state.currentDevice.command("led.capsLockIndicator.color").then((color: string | undefined) => {
+          const colorComponents = (color ?? "")
+            .split(/\s+/)
+            .slice(0, 3)
+            .map(value => parseInt(value, 10));
+          const [r, g, b] = colorComponents;
+
+          if (colorComponents.length === 3 && colorComponents.every(value => Number.isFinite(value))) {
+            newKbData.capsLockIndicatorColor = { r, g, b };
+          }
+        });
+      }
 
       newKbData.showDefaults =
         store.get("settings.showDefaults") === undefined ? false : (store.get("settings.showDefaults") as boolean);
@@ -388,6 +426,15 @@ const Preferences = (props: PreferencesProps) => {
       await state.currentDevice.command("led.brightnessUG", kbData.ledBrightnessUG.toString());
       if (kbData.ledIdleTimeLimit >= 0)
         await state.currentDevice.command("idleleds.time_limit", kbData.ledIdleTimeLimit.toString());
+      if (kbData.capsLockIndicatorSupported) {
+        await state.currentDevice.command("led.capsLockIndicator.enabled", kbData.capsLockIndicatorEnabled ? "1" : "0");
+        await state.currentDevice.command(
+          "led.capsLockIndicator.color",
+          kbData.capsLockIndicatorColor.r.toString(),
+          kbData.capsLockIndicatorColor.g.toString(),
+          kbData.capsLockIndicatorColor.b.toString(),
+        );
+      }
       store.set("settings.showDefaults", kbData.showDefaults);
       // QUKEYS
       await state.currentDevice.command("qukeys.holdTimeout", kbData.qukeysHoldTimeout.toString());
@@ -810,7 +857,12 @@ const Preferences = (props: PreferencesProps) => {
                     <>
                       <TabsContent value="Battery">
                         <motion.div initial="hidden" animate="visible" variants={tabVariants}>
-                          <BatterySettings wireless={wireless} changeWireless={updateWireless} isCharging={false} deviceType={state.currentDevice.device.info.product as string} />
+                          <BatterySettings
+                            wireless={wireless}
+                            changeWireless={updateWireless}
+                            isCharging={false}
+                            deviceType={state.currentDevice.device.info.product as string}
+                          />
                           <EnergyManagement wireless={wireless} changeWireless={updateWireless} updateTab={handleTabChange} />
                         </motion.div>
                       </TabsContent>


### PR DESCRIPTION
Draft UI support for a configurable Caps Lock LED indicator.

Discussion:
- Dygmalab/Bazecor#1126

Related firmware draft PRs:
- Dygmalab/NeuronLedLibrary#10
- Dygmalab/NeuronWirelessLibs#35
- Dygmalab/NeuronWireless_defy#23

This PR adds a Bazecor LED setting that is shown only when the connected firmware exposes both Focus commands via help:
- led.capsLockIndicator.enabled
- led.capsLockIndicator.color

Current scope:
- preference state for Caps Lock indicator support/enabled/color
- Focus command read/write in Preferences
- LED settings UI with enable switch and color picker
- compatibility guard for older firmware

Not included here:
- firmware live LED overlay behavior
- host Caps Lock state handling

Validation performed locally:
- Prettier check passed for changed files
- ESLint passed for changed files with existing warnings only

Full project typecheck currently fails on pre-existing TypeScript errors outside this change.