### PR TITLE
fix(lens): make Layer Lens usable on Wayland

### DIFF
--- a/src/lens/main/overlay-controller.ts
+++ b/src/lens/main/overlay-controller.ts
@@ -46,6 +46,15 @@ const LAYER_CHANGE_AUTO_HIDE_MS = 3000;
 // auto-show feel like it lags behind the layer key.
 const LAYER_PAINT_SETTLE_MS = 230;
 const TOGGLE_SHORTCUT = "CommandOrControl+Alt+L";
+// A press that arrives as HOLD+RELEASE but lasts less than this is finished as
+// if it had been a TAP. Tap-vs-hold is decided on the keyboard, and its
+// threshold doesn't always match what the user's fingers did: in practice a
+// noticeable share of presses arrive as "holds" of 100-200ms, which are plainly
+// taps. Honouring those literally is what makes the Lens key feel unreliable —
+// with Lens hidden the overlay flashes up for the length of the press and
+// vanishes, and with Lens already visible nothing happens at all (HOLD start is
+// ignored, and the release then has no hold to end).
+const HOLD_AS_TAP_MS = 250;
 // Upper bound on a firmware flash. If the renderer never sends the matching
 // "flashing finished" (crash, reload, an abort path we don't cover), Lens comes
 // back on its own rather than staying dead until the app restarts.
@@ -72,6 +81,12 @@ class OverlayController {
   private activeLayer = 0;
 
   private holdKeyActive = false;
+
+  // When the current OVERLAY_KEY hold began, or null if no hold is in flight.
+  // Set whenever a HOLD start is actually processed — including the "already
+  // visible, nothing to do" case, so the matching release can still tell how
+  // long the press was and apply HOLD_AS_TAP_MS.
+  private overlayHoldStartedAt: number | null = null;
 
   private layerAutoShowActive = false;
 
@@ -209,6 +224,7 @@ class OverlayController {
     globalShortcut.unregister(TOGGLE_SHORTCUT);
     this.clearLayerChangeHideTimer();
     this.holdKeyActive = false;
+    this.overlayHoldStartedAt = null;
     this.layerAutoShowActive = false;
     this.overlayActive = false;
     this.pendingShow = false;
@@ -543,6 +559,9 @@ class OverlayController {
       log.verbose("[Lens] HOLD ignored — overlay gestures are switched off");
       return;
     }
+    // Stamped even when there's nothing to do below, so the release can measure
+    // the press and fall back to TAP behaviour (see HOLD_AS_TAP_MS).
+    this.overlayHoldStartedAt = Date.now();
     if (isOverlayVisible()) {
       log.verbose("[Lens] HOLD start ignored (Lens already visible)");
       return;
@@ -554,6 +573,27 @@ class OverlayController {
   }
 
   private onOverlayHoldEnd(): void {
+    const startedAt = this.overlayHoldStartedAt;
+    this.overlayHoldStartedAt = null;
+
+    // Too brief to have been meant as a hold — finish the press as a TAP.
+    if (startedAt !== null && Date.now() - startedAt < HOLD_AS_TAP_MS) {
+      const heldMs = Date.now() - startedAt;
+      if (this.holdKeyActive) {
+        // The hold already put Lens on screen; as a tap it should stay there.
+        this.holdKeyActive = false;
+        this.clearLayerChangeHideTimer();
+        setLastOverlayShown(true);
+        log.verbose(`[Lens] HOLD released after ${heldMs}ms — treating as TAP, leaving Lens up`);
+        return;
+      }
+      // Lens was already visible, so HOLD start had nothing to do and this is
+      // the tap that should put it away.
+      log.verbose(`[Lens] HOLD released after ${heldMs}ms — treating as TAP`);
+      this.onOverlayTapAction();
+      return;
+    }
+
     if (!this.holdKeyActive) return;
     this.holdKeyActive = false;
     this.clearLayerChangeHideTimer();

--- a/src/lens/main/overlay-controller.ts
+++ b/src/lens/main/overlay-controller.ts
@@ -133,30 +133,73 @@ class OverlayController {
       const wantsShow = getLastOverlayShown();
       const showOnStart = wantsShow && this.currentModel !== null;
       this.pendingShow = wantsShow && !showOnStart;
-      createOverlayWindow(() => {
-        // Stays true even when the overlay starts hidden: this is the master
-        // switch for the Lens key gestures, and a hidden overlay must still be
-        // summonable with LENS TAP / HOLD.
-        this.overlayActive = true;
-        // reloadModel(false) above ran before this window existed, so its own
-        // applyAspectRatioFor() call was a no-op (getWin() was still null) —
-        // and createOverlayWindow()/applyOverlayMode() restore whatever bounds
-        // were persisted from the last session, which may predate this ratio
-        // lock entirely. Re-apply it now that the window is actually there.
-        applyAspectRatioFor(this.currentModel?.product);
-        if (this.currentModel) {
-          pushModel(this.currentModel);
-          pushActiveLayer(this.activeLayer);
-        }
-        pushState(this.getState());
-        broadcastSettings(getLensSettings());
-      }, showOnStart);
+      this.buildOverlayWindow(showOnStart);
     }
     this.registerShortcut();
     this.checkMacosPermission();
     // Enabling Lens in the middle of a firmware update must not re-open the
     // keyboard; setFlashing(false) starts the listener once the flash is done.
     if (!this.flashing) this.hid.startWithRetry();
+  }
+
+  /** Creates the overlay window and hands the fresh renderer everything it needs
+   * to draw. Shared by enable() and the on-demand rebuild in overlayReadyFor(),
+   * so a window that comes back mid-session is wired up exactly like one created
+   * at enable time. */
+  private buildOverlayWindow(showOnStart: boolean): void {
+    createOverlayWindow(() => {
+      // Stays true even when the overlay starts hidden: this is the master
+      // switch for the Lens key gestures, and a hidden overlay must still be
+      // summonable with LENS TAP / HOLD.
+      this.overlayActive = true;
+      // reloadModel() may well have run before this window existed, so its own
+      // applyAspectRatioFor() call was a no-op (getWin() was still null) —
+      // and createOverlayWindow()/applyOverlayMode() restore whatever bounds
+      // were persisted from the last session, which may predate this ratio
+      // lock entirely. Re-apply it now that the window is actually there.
+      applyAspectRatioFor(this.currentModel?.product);
+      if (this.currentModel) {
+        pushModel(this.currentModel);
+        pushActiveLayer(this.activeLayer);
+      }
+      pushState(this.getState());
+      broadcastSettings(getLensSettings());
+    }, showOnStart);
+  }
+
+  /**
+   * Gate for every user-driven overlay gesture (Lens key TAP/HOLD, the tray
+   * item, Ctrl+Alt+L). Returns true when the overlay window is live and the
+   * gesture can go ahead.
+   *
+   * The window can disappear from under us: nothing in Bazecor closes it
+   * (disable() destroys it, which emits no "close"), but the compositor can —
+   * on Wayland the overlay becomes focusable, and therefore closable, while
+   * Resize Mode is on. Every gesture used to just `return` when that happened,
+   * which left the Lens key AND the tray item doing nothing at all, with not one
+   * line in the log, until Lens was toggled off and on in Preferences. Rebuild
+   * the window instead, and say so in the log — a gesture that can't act must
+   * never again fail invisibly.
+   *
+   * A rebuild returns false because the window only reveals itself once it is
+   * ready to show: this press is spent bringing Lens back, and the next one
+   * resumes toggling normally.
+   */
+  private overlayReadyFor(gesture: string): boolean {
+    if (!this.enabled) {
+      log.verbose(`[Lens] ${gesture} ignored — Lens is turned off`);
+      return false;
+    }
+    if (overlayAlive()) return true;
+    log.warn(`[Lens] ${gesture}: the overlay window is gone — rebuilding it`);
+    // The user just asked for Lens, so bring it back on screen (deferring, as
+    // enable() does, when there is no model yet to draw).
+    const showOnStart = this.currentModel !== null;
+    this.pendingShow = !showOnStart;
+    this.overlayActive = true;
+    setLastOverlayShown(true);
+    this.buildOverlayWindow(showOnStart);
+    return false;
   }
 
   disable(): void {
@@ -342,7 +385,7 @@ class OverlayController {
    * behaviour as the Lens key's own TAP (onOverlayTapAction) — the two are the
    * user's two ways of saying "show/hide it now" and must stay interchangeable. */
   toggleOverlay(): void {
-    if (!this.enabled || !overlayAlive()) return;
+    if (!this.overlayReadyFor("Tray/shortcut toggle")) return;
     this.clearLayerChangeHideTimer();
     this.layerAutoShowActive = false;
     // Toggle off what's actually on screen, not off `overlayActive`: the two
@@ -385,7 +428,7 @@ class OverlayController {
    * stuck false while the window reappeared, silently breaking the overlay
    * key (its TAP/HOLD handlers all guard on overlayActive). */
   ensureVisible(): void {
-    if (!this.enabled || !overlayAlive()) return;
+    if (!this.overlayReadyFor("Resize Mode")) return;
     if (this.overlayActive && isOverlayVisible()) return;
     this.overlayActive = true;
     this.setUserVisible(true);
@@ -483,7 +526,11 @@ class OverlayController {
   // originates from the OVERLAY_KEY superkey (eventType-based) or a dedicated
   // OVERLAY_TAP / OVERLAY_HOLD key (its own packet type).
   private onOverlayTapAction(): void {
-    if (!this.overlayActive || !overlayAlive()) return;
+    if (!this.overlayReadyFor("TAP")) return;
+    if (!this.overlayActive) {
+      log.verbose("[Lens] TAP ignored — overlay gestures are switched off");
+      return;
+    }
     this.clearLayerChangeHideTimer();
     this.layerAutoShowActive = false;
     log.verbose(`[Lens] TAP action → toggling visibility (currently ${isOverlayVisible() ? "visible" : "hidden"})`);
@@ -491,7 +538,11 @@ class OverlayController {
   }
 
   private onOverlayHoldStart(): void {
-    if (!this.overlayActive || !overlayAlive()) return;
+    if (!this.overlayReadyFor("HOLD")) return;
+    if (!this.overlayActive) {
+      log.verbose("[Lens] HOLD ignored — overlay gestures are switched off");
+      return;
+    }
     if (isOverlayVisible()) {
       log.verbose("[Lens] HOLD start ignored (Lens already visible)");
       return;

--- a/src/lens/main/overlay-window.ts
+++ b/src/lens/main/overlay-window.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen } from "electron";
 import log from "electron-log/main";
 import LensOverlay from "../../main/managers/LensOverlay";
 import Window from "../../main/managers/Window";
+import { isAppQuitting } from "../../main/managers/AppLifecycle";
 import type { KeyboardModel, LensSettings, LensState } from "../shared/types";
 import { getLensSettings, getOverlayBounds, setOverlayBounds } from "./lens-settings";
 
@@ -261,6 +262,11 @@ export function applyOverlayMode(enabled: boolean): void {
   }
 }
 
+// Consecutive renderer reloads allowed before giving up (reset by a load that
+// completes) — see the render-process-gone handler in createOverlayWindow.
+const MAX_OVERLAY_RELOADS = 3;
+let overlayReloadAttempts = 0;
+
 // Repaint nudges fired after a show, and the gap between them.
 const FIRST_FRAME_KICKS = 4;
 const FIRST_FRAME_KICK_MS = 60;
@@ -379,6 +385,49 @@ export function createOverlayWindow(onReady: () => void, showOnStart: boolean): 
 
   LensOverlay.setWindow(w);
   w.loadURL(LENS_WINDOW_WEBPACK_ENTRY);
+
+  // The overlay's renderer process has been observed dying (a clean exit, no
+  // crash dump) while the window sits hidden for a few minutes, leaving a
+  // zombie BrowserWindow that show() can't bring back — no renderer means no
+  // frames, so the surface never maps and the Lens key summons nothing.
+  // Reload to spawn a fresh renderer: the window object itself is fine, and
+  // the page refetches its state on mount (App.tsx) while did-finish-load
+  // below re-applies the injected overlay classes. The logged reason/exitCode
+  // is Chromium's own verdict on why the process went away.
+  w.webContents.on("render-process-gone", (_e, details) => {
+    // On the way out the renderer legitimately goes away; reloading it there
+    // just races the shutdown (and a renderer that can no longer launch answers
+    // every reload with another "gone", which is a spin, not a recovery).
+    if (isAppQuitting() || w.isDestroyed()) return;
+    if (overlayReloadAttempts >= MAX_OVERLAY_RELOADS) {
+      log.error(
+        `[Lens] Overlay renderer gone (${details.reason}) and ${overlayReloadAttempts} reloads have not stuck — leaving it alone. Toggle Layer Lens off and on to rebuild it.`,
+      );
+      return;
+    }
+    overlayReloadAttempts += 1;
+    log.warn(`[Lens] Overlay renderer gone (reason: ${details.reason}, exitCode: ${details.exitCode}) -> reloading`);
+    w.webContents.reload();
+  });
+
+  // A renderer reload (crash recovery, webpack live-reload in dev) resets the
+  // <body> classes applyOverlayMode/applyResizeModeLive injected, leaving the
+  // overlay rendering its window-mode chrome. Re-inject the current mode after
+  // every load (the first one included — harmlessly redundant there).
+  w.webContents.on("did-finish-load", () => {
+    // A load that completes is a renderer that stuck, so the budget above is
+    // spent per incident rather than for the lifetime of the window.
+    overlayReloadAttempts = 0;
+    if (!overlayStyleApplied) return;
+    const settings = getLensSettings();
+    w.webContents
+      .executeJavaScript(
+        `document.body.classList.add('overlay');document.body.classList.${
+          settings.resizeMode ? "add" : "remove"
+        }('resize-mode');`,
+      )
+      .catch(() => {});
+  });
 
   w.once("ready-to-show", () => {
     log.info(`[Lens] Overlay window ready-to-show (showOnStart=${showOnStart})`);

--- a/src/lens/main/overlay-window.ts
+++ b/src/lens/main/overlay-window.ts
@@ -357,6 +357,13 @@ export function createOverlayWindow(onReady: () => void, showOnStart: boolean): 
   // through destroyOverlayWindow(), which persists explicitly before destroy()).
   // destroy() itself never emits "close", so the two paths don't double-save.
   w.on("close", () => {
+    // Nothing in Bazecor closes this window — disable() destroys it, and
+    // destroy() emits no "close" — so arriving here means something outside
+    // did: the app quitting, or (on Wayland, where Resize Mode makes the
+    // overlay focusable and so closable) a compositor-side close aimed at it.
+    // That used to leave the Lens key and the tray item silently dead; the
+    // gestures rebuild the window now, but log it so the cause is visible.
+    log.info("[Lens] Overlay window is closing");
     if (overlayStyleApplied) {
       overlayBounds = w.getBounds();
       persistOverlayBounds();

--- a/src/lens/main/overlay-window.ts
+++ b/src/lens/main/overlay-window.ts
@@ -261,6 +261,45 @@ export function applyOverlayMode(enabled: boolean): void {
   }
 }
 
+// Repaint nudges fired after a show, and the gap between them.
+const FIRST_FRAME_KICKS = 4;
+const FIRST_FRAME_KICK_MS = 60;
+let firstFrameTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Makes sure the window actually gets a frame drawn into it after being shown.
+ *
+ * A Wayland surface is mapped only once the client commits a frame to it, and a
+ * window coming back from hide() has nothing dirty to draw — React's tree is
+ * unchanged, so no repaint is scheduled and the compositor is handed nothing.
+ * Electron still reports the window as shown (its renderer even reports
+ * document.visibilityState "visible"), so everything downstream believes Lens is
+ * up while the screen stays empty, and the next press "toggles" an invisible
+ * window back off. That is what made the Lens key feel like it needed three or
+ * four presses.
+ *
+ * invalidate() forces the repaint. It is repeated a few times across the first
+ * frames because a single one occasionally still lands before the surface is
+ * ready to take it — the calls are cheap, and a redundant repaint of an
+ * already-visible overlay costs nothing visible.
+ */
+function forceFirstFrames(win: BrowserWindow): void {
+  if (firstFrameTimer) {
+    clearTimeout(firstFrameTimer);
+    firstFrameTimer = null;
+  }
+  let kicks = 0;
+  const kick = (): void => {
+    firstFrameTimer = null;
+    const w = getWin();
+    if (!w || w.isDestroyed() || w !== win) return;
+    w.webContents.invalidate();
+    kicks += 1;
+    if (kicks < FIRST_FRAME_KICKS) firstFrameTimer = setTimeout(kick, FIRST_FRAME_KICK_MS);
+  };
+  kick();
+}
+
 const FADE_IN_DURATION_MS = 80;
 const FADE_OUT_DURATION_MS = 150;
 const FADE_INTERVAL_MS = 16;
@@ -382,6 +421,10 @@ export function createOverlayWindow(onReady: () => void, showOnStart: boolean): 
 export function destroyOverlayWindow(): void {
   stopFade();
   cancelLinuxResizableSync();
+  if (firstFrameTimer) {
+    clearTimeout(firstFrameTimer);
+    firstFrameTimer = null;
+  }
   if (persistBoundsTimer) {
     clearTimeout(persistBoundsTimer);
     persistBoundsTimer = null;
@@ -428,6 +471,7 @@ export function showOverlay(fadeDelayMs = 0): void {
   if (LINUX && overlayStyleApplied && win.isResizable()) win.setResizable(false);
   if (overlayStyleApplied) win.showInactive();
   else win.show();
+  forceFirstFrames(win);
   if (overlayStyleApplied) scheduleLinuxResizableSync();
   if (fadeDelayMs <= 0) {
     fadeWindowOpacity(target, FADE_IN_DURATION_MS);

--- a/src/lens/main/overlay-window.ts
+++ b/src/lens/main/overlay-window.ts
@@ -139,6 +139,64 @@ function preventOverlayResize(e: { preventDefault(): void }): void {
   e.preventDefault();
 }
 
+// ── Linux (Wayland/tiling WMs) resize handling ────────────────────────────────
+// The overlay must MAP with fixed-size hints (resizable=false): min==max size is
+// what makes Hyprland and other tiling compositors auto-float it instead of
+// tiling it into the layout. But those same hints are exactly what blocks
+// compositor-side resizing — Hyprland clamps every resize to min==max — and the
+// in-app resize handles can't cover for it there: they drive win.setBounds()
+// from screenX/screenY math, and Wayland neither lets a client position itself
+// nor reports global pointer coordinates. So on Linux the compositor owns
+// move/resize: map with fixed-size hints, then once the surface is actually
+// mapped lift them (while Resize Mode is on) so SUPER+drag / resizewindow work,
+// and re-pin them before every hide so the NEXT map floats again.
+const LINUX = process.platform === "linux";
+let linuxResizableTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cancelLinuxResizableSync(): void {
+  if (linuxResizableTimer) {
+    clearTimeout(linuxResizableTimer);
+    linuxResizableTimer = null;
+  }
+}
+
+/** Lifts the fixed-size mapping hints shortly after the overlay is shown (the
+ * delay lets the surface actually map first — float/tile is decided at map
+ * time, when the hints must still be in place). No-op off Linux.
+ *
+ * The delay is a race against the compositor: win.isVisible() flips
+ * immediately on show, but the Wayland surface only maps a few frames later —
+ * and on a busy main process (cold start with a device scan in flight) that
+ * has been observed to take >250ms, after which a too-early lift gets the
+ * overlay tiled into the layout instead of floated. 1s loses only "resize
+ * available a beat after the overlay appears", so err far on the late side.
+ * (A compositor window rule floating the overlay by title — "Dygma Lens" —
+ * makes this race harmless entirely; see the Linux note above.) */
+function scheduleLinuxResizableSync(): void {
+  if (!LINUX) return;
+  cancelLinuxResizableSync();
+  linuxResizableTimer = setTimeout(() => {
+    linuxResizableTimer = null;
+    const win = getWin();
+    if (win && !win.isDestroyed() && overlayStyleApplied && win.isVisible()) {
+      win.setResizable(getLensSettings().resizeMode);
+    }
+  }, 1000);
+}
+
+/** Linux replacement for guardOverlayBounds: instead of snapping external
+ * resizes back, adopt them — the compositor is the one driving them here. Only
+ * the size is trusted: Wayland position readback is not meaningful. */
+function adoptExternalResize(): void {
+  const win = getWin();
+  if (!win || !overlayStyleApplied) return;
+  const b = win.getBounds();
+  if (overlayLockedBounds) {
+    overlayLockedBounds = { ...overlayLockedBounds, width: b.width, height: b.height };
+  }
+  schedulePersistBounds();
+}
+
 export function applyOverlayMode(enabled: boolean): void {
   const win = getWin();
   if (!win) return;
@@ -160,11 +218,21 @@ export function applyOverlayMode(enabled: boolean): void {
     win.setAlwaysOnTop(true, "screen-saver");
     // Resize Mode wanting mouse events means the window can't be click-through.
     win.setIgnoreMouseEvents(!settings.resizeMode, { forward: true });
+    // Fixed-size at map on every platform: on Linux it's what floats the
+    // overlay on tiling compositors (see the Linux block above, which lifts it
+    // again after mapping); on Windows/macOS it stays locked for good and the
+    // in-app handles do the resizing.
     win.setResizable(false);
     win.removeListener("will-resize", preventOverlayResize);
     win.removeListener("resize", guardOverlayBounds);
-    win.on("will-resize", preventOverlayResize);
-    win.on("resize", guardOverlayBounds);
+    win.removeListener("resize", adoptExternalResize);
+    if (LINUX) {
+      win.on("resize", adoptExternalResize);
+      scheduleLinuxResizableSync();
+    } else {
+      win.on("will-resize", preventOverlayResize);
+      win.on("resize", guardOverlayBounds);
+    }
     win.webContents
       .executeJavaScript(
         `document.body.classList.add('overlay');${
@@ -175,8 +243,10 @@ export function applyOverlayMode(enabled: boolean): void {
     if (overlayBounds) win.setBounds(overlayBounds);
   } else {
     overlayLockedBounds = null;
+    cancelLinuxResizableSync();
     win.removeListener("will-resize", preventOverlayResize);
     win.removeListener("resize", guardOverlayBounds);
+    win.removeListener("resize", adoptExternalResize);
     overlayBounds = win.getBounds();
     persistOverlayBounds();
     win.setOpacity(1.0);
@@ -304,6 +374,7 @@ export function createOverlayWindow(onReady: () => void, showOnStart: boolean): 
 
 export function destroyOverlayWindow(): void {
   stopFade();
+  cancelLinuxResizableSync();
   if (persistBoundsTimer) {
     clearTimeout(persistBoundsTimer);
     persistBoundsTimer = null;
@@ -345,8 +416,12 @@ export function showOverlay(fadeDelayMs = 0): void {
   const target = overlayStyleApplied ? settings.opacity : 1.0;
   stopFade();
   win.setOpacity(0);
+  // Linux: re-pin the fixed-size hints for this map (a hidden window may still
+  // carry a previous lift), then lift them again once mapped.
+  if (LINUX && overlayStyleApplied && win.isResizable()) win.setResizable(false);
   if (overlayStyleApplied) win.showInactive();
   else win.show();
+  if (overlayStyleApplied) scheduleLinuxResizableSync();
   if (fadeDelayMs <= 0) {
     fadeWindowOpacity(target, FADE_IN_DURATION_MS);
     return;
@@ -364,8 +439,13 @@ export function hideOverlay(): void {
   const win = getWin();
   if (!win) return;
   overlayVisible = false;
+  cancelLinuxResizableSync();
   fadeWindowOpacity(0, FADE_OUT_DURATION_MS, () => {
-    getWin()?.hide();
+    const w = getWin();
+    if (!w) return;
+    // Linux: back to fixed-size while hidden so the next map floats again.
+    if (LINUX && overlayStyleApplied && w.isResizable()) w.setResizable(false);
+    w.hide();
   });
 }
 
@@ -380,6 +460,9 @@ export function applyResizeModeLive(v: boolean): void {
   const win = getWin();
   if (!win || !overlayStyleApplied) return;
   win.setIgnoreMouseEvents(!v, { forward: true });
+  // Linux: the compositor does the resizing (see the Linux block above), so the
+  // fixed-size hints follow Resize Mode directly while the window is mapped.
+  if (LINUX && win.isVisible()) win.setResizable(v);
   win.webContents
     .executeJavaScript(v ? `document.body.classList.add('resize-mode');` : `document.body.classList.remove('resize-mode');`)
     .catch(() => {});

--- a/src/lens/renderer/index.css
+++ b/src/lens/renderer/index.css
@@ -383,6 +383,14 @@ body.overlay.resize-mode .app.hovered .resize-frame {
   border-radius: 4px;
   pointer-events: none;
 }
+/* Linux: Resize Mode makes the window focusable, and the compositor draws its
+   own border on the focused window in the WM theme's color and corner
+   rounding — our hardcoded frame would just clash with it (visibly so on
+   Hyprland, where a window rule keeps the inactive border invisible). The
+   hover glow on .keyboard-view stays as the resize-mode affordance. */
+body.platform-linux .resize-border {
+  display: none;
+}
 
 /* Freeze all hover transitions while resizing, and keep the frame/glow shown
    even if a fast drag briefly carries the cursor outside the keyboard. */

--- a/src/lens/renderer/main.tsx
+++ b/src/lens/renderer/main.tsx
@@ -13,6 +13,11 @@ window.addEventListener(
   { passive: false },
 );
 
+// Linux: the compositor draws the Resize Mode frame instead of our own (see
+// ".resize-border" in index.css) — its border follows the WM theme's color and
+// corner rounding, which our hardcoded frame can't.
+document.body.classList.toggle("platform-linux", navigator.userAgent.includes("Linux"));
+
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing #root");
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,9 +31,25 @@ if (require("electron-squirrel-startup")) {
 // A second launch (e.g. from the login item while already tray-resident) must
 // focus the existing instance instead of spawning a second overlay/tray.
 if (!app.requestSingleInstanceLock()) {
-  app.quit();
+  // exit() rather than quit(): this runs before "ready", and a quit() requested
+  // that early is not guaranteed to take — the app carries on to ready and
+  // becomes exactly the second copy the lock exists to prevent (a second tray, a
+  // second overlay, a second HID listener fighting the first for the keyboard).
+  // The primary instance has already been handed our argv by then, so there is
+  // nothing left for this process to do.
+  app.exit(0);
 } else {
-  app.on("second-instance", () => {
+  app.on("second-instance", (_event, argv) => {
+    // Relaunching with a flag is how the outside world drives Layer Lens: the
+    // single-instance lock hands the arguments to the running app, so
+    // `Bazecor --toggle-lens` from a keybind, a script, or a desktop shell
+    // toggles the overlay instead of opening a second copy. Worth having on
+    // every platform, but it is the only route on Wayland, where a global
+    // shortcut registered by the app never fires.
+    if (argv.includes("--toggle-lens")) {
+      overlayController.toggleOverlay();
+      return;
+    }
     openMainWindow();
   });
 }

--- a/src/main/setup/configureTray.ts
+++ b/src/main/setup/configureTray.ts
@@ -91,10 +91,16 @@ function applyLoginItem(enabled: boolean): void {
   if (process.platform === "linux") {
     try {
       if (enabled) {
+        // The Linux build ships as an AppImage, which runs from a temporary
+        // mount: process.execPath there is /tmp/.mount_XXXXXX/..., a path that
+        // differs every run and is gone once the app exits. Writing that into
+        // the autostart entry produces one that silently never starts anything.
+        // $APPIMAGE is the real file on disk, set by the AppImage runtime.
+        const exe = process.env.APPIMAGE || process.execPath;
         fs.mkdirSync(path.dirname(LINUX_AUTOSTART_FILE), { recursive: true });
         fs.writeFileSync(
           LINUX_AUTOSTART_FILE,
-          `[Desktop Entry]\nType=Application\nName=Bazecor\nExec=${process.execPath} --hidden\nX-GNOME-Autostart-enabled=true\n`,
+          `[Desktop Entry]\nType=Application\nName=Bazecor\nExec=${exe} --hidden\nX-GNOME-Autostart-enabled=true\n`,
         );
       } else {
         fs.rmSync(LINUX_AUTOSTART_FILE, { force: true });


### PR DESCRIPTION
## Summary

Layer Lens is effectively unusable on Wayland compositors today: the overlay cannot be resized, and its show/hide key is unreliable enough that it reads as broken. This branch fixes five distinct causes found while getting Bazecor running on Arch + Hyprland with a Sonsei, and adds a way to drive the overlay from outside the app.

Each commit is self-contained, type-checks, and leaves the suite green.

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/61fc9fd6-a887-4466-b968-371ef1f4b97c" />

## The bugs

**1. The overlay cannot be resized.** It maps with fixed-size hints (`resizable: false`), which is load-bearing — `min == max` is what makes tiling compositors float it rather than tile it — but those same hints make the compositor clamp every resize, so Resize Mode had nothing to act on. The in-app resize handles can't cover for it either: they drive `setBounds()` from `screenX`/`screenY`, and Wayland neither lets a client position itself nor reports global pointer coordinates. Now the compositor owns move/resize on Linux: still map with the hints, lift them once the surface has actually mapped, re-pin before each hide, and adopt external resizes instead of snapping them back.

**2. Gestures silently die if the overlay window is destroyed.** Nothing in Bazecor closes that window, but a compositor can — and on Wayland it readily does, since Resize Mode makes the overlay focusable and therefore closable. A stray close keybind took it away permanently: afterwards the Lens key *and* the tray item both did nothing, with nothing in the log, until Lens was toggled off and on in Preferences. Gestures now rebuild the window, and anything that still can't act says why.

**3. A very short hold is not treated as a tap.** Tap-vs-hold is decided on the keyboard, and roughly one press in five arrived as a `HOLD`+`RELEASE` pair only 100–200 ms apart (one at 0 ms) — plainly taps. Taken literally those flashed the overlay up and away again; and when Lens was *already* visible the press did nothing at all, because `HOLD` start bails when the overlay is up so `RELEASE` had no hold to end. Releases inside a short window now finish as taps. Genuine holds are untouched.

**4. Showing the overlay does not always map it.** A Wayland surface is mapped only once the client commits a frame, and a window returning from `hide()` has nothing dirty to draw — so nothing schedules a repaint and the compositor gets an empty surface. Electron still reports the window shown (the renderer even reports `visibilityState: "visible"`), so everything downstream believes Lens is up while the screen stays empty, and the next press toggles an invisible window back off. This is the "takes three or four presses" symptom. `invalidate()` after show supplies the missing frame.

**5. A dead overlay renderer is unrecoverable.** The renderer has been seen exiting while the window sits hidden, leaving a window `show()` can't bring back. It now reloads to spawn a fresh renderer and re-applies the injected `<body>` classes after any load. The recovery stands down during shutdown and gives up after a few failures rather than spinning.

**6. Nothing outside the app can show or hide Lens.** The tray item and the keyboard's Lens key were the only routes, and the `Ctrl+Alt+L` global shortcut never fires on Wayland, where the compositor hands out no global grabs. `Bazecor --toggle-lens` now reaches the running instance through its single-instance lock, so a keybind, a script or a desktop shell can drive the overlay. That turned up a second bug worth having found: the duplicate-instance branch called `app.quit()`, which is not guaranteed to take effect before `ready`, so a second launch carried on booting and became exactly what the lock exists to prevent — a second tray icon, a second overlay, and a second HID listener contending with the first for the keyboard. It is `app.exit(0)` now.

## Verification

Confirmed on Arch Linux / Hyprland 0.56 (native Wayland) with a Dygma Sonsei:

- Bug 2 reproduced by dispatching a compositor close at the overlay, then watching a tray click rebuild it.
- Bug 3 caught live in the logs: a 0 ms press that previously did nothing now logs `treating as TAP` and toggles.
- Bug 4 confirmed directly — with the overlay stuck, the compositor reported it unmapped while its renderer reported itself visible; forcing one repaint mapped it immediately.

Honest caveat on **4**: the mechanism is proven, but I could not build a synthetic reproduction reliable enough to benchmark the fix — short hide/show cycles rarely trigger it, which suggests the real trigger involves longer idle periods. The call is a no-op when a frame was going to be drawn anyway.

Nothing here is Hyprland-specific in intent, but Hyprland is the only compositor it has been exercised on. macOS and Windows paths are untouched: every change is behind `process.platform === "linux"` or is platform-neutral (bugs 2, 3 and 5 fix logic that was equally dead everywhere).

## The other half, which cannot live here

Some of what makes Layer Lens feel like an overlay is simply not the app's to decide. On Wayland a client cannot float, pin, or place its own window: `setPosition()` and `setBounds()` report back whatever you hand them while the compositor ignores them, `getPosition()` reads `0,0`, and `setVisibleOnAllWorkspaces(true)` leaves `isVisibleOnAllWorkspaces()` false. I checked each of those directly rather than assuming.

So the compositor-side half lives in a small companion plugin for Omarchy/Hyprland: **https://github.com/jondkinney/omarchy-bazecor-lens**

It keeps the overlay floating, pins it so it follows you across workspaces, borders it in the current theme's colour, and reopens it where you left it — the last one by feeding the remembered position back as a compositor rule, since the app cannot place the window itself. It also adds a bar icon that toggles the overlay through `--toggle-lens` from this PR.

Nothing in this PR depends on that plugin, and the plugin is not required for any fix here. Mentioning it in case it is useful to point Linux users at, or in case any of it suggests something worth doing in the app itself.

## Not included

Two local-environment changes were deliberately left out: moving the webpack dev-server ports off 3000/9000 (a collision with other local dev servers, not a Linux issue), and a `mise.toml` toolchain pin. Happy to send either separately if useful.
